### PR TITLE
[Installation] Error during installation on Window (#274)

### DIFF
--- a/docs/install/windows/windows_installer.bat
+++ b/docs/install/windows/windows_installer.bat
@@ -31,7 +31,7 @@ echo **Installing requirements...**
 REM CONFIGURATION
 echo **Set default configuration...**
 cd %config_path%
-copy default_config.json ../config.json
+copy default_config.json ..\config.json
 
 REM BOT MODULES INSTALL
 echo **Installing modules...**


### PR DESCRIPTION
In the command line 'copy default_config.json ../config.json' (line 34) Windows returns an error with the '/' because a '\\' is expected.