### PR TITLE
Remove tensorflow from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,10 +24,6 @@ newspaper3k
 pytrends
 vaderSentiment
 
-# ML tools
-tensorflow
-tensorflow-tensorboard
-
 ## Others
 psutil
 colorlog


### PR DESCRIPTION
- Remove tensorflow currently unused and python3.7 incompatible