### PR TITLE
Add error log when started with sudo

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -13,7 +13,7 @@
 #
 #  You should have received a copy of the GNU Lesser General Public
 #  License along with this library.
-
+import os
 from logging import WARNING
 from enum import Enum
 from typing import NewType, Any, Dict
@@ -530,9 +530,9 @@ class FeePropertyColumns(Enum):
     COST = "cost"  # fee amount
 
 
-class DeliveryPlatformsName(Enum):
-    WINDOWS = "windows"
-    LINUX = "linux"
+class PlatformsName(Enum):
+    WINDOWS = "nt"
+    LINUX = "posix"
     MAC = "mac"
 
 
@@ -541,3 +541,7 @@ WATCHED_SYMBOLS_TIME_FRAME = TimeFrames.ONE_HOUR
 CONFIG_WATCHED_SYMBOLS = "watched_symbols"
 
 OCTOBOT_KEY = b'uVEw_JJe7uiXepaU_DR4T-ThkjZlDn8Pzl8hYPIv7w0='
+
+
+def get_os():
+    return PlatformsName(os.name)

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -18,6 +18,8 @@ import logging
 import os
 import sys
 
+from config import PlatformsName, get_os
+
 MIN_PYTHON_VERSION = (3, 6)
 
 # check python version
@@ -33,3 +35,8 @@ if not current_version >= MIN_PYTHON_VERSION:
 sys.path.append(os.path.dirname(sys.executable))
 
 # if compatible version, can proceed with imports
+
+# check sudo rights
+if get_os() is not PlatformsName.WINDOWS and os.getuid() == 0:
+    logging.warning("OctoBot is started with admin / sudo rights that are not required, "
+                    "please check you starting command ")


### PR DESCRIPTION
- Add error in logs when OctoBot is started with admin / sudo rights.


resolves #298 