### PR TITLE
#691 fixed order database desync when using websocket

### DIFF
--- a/interfaces/trading_util.py
+++ b/interfaces/trading_util.py
@@ -99,8 +99,7 @@ def force_real_traders_refresh():
     for trader in get_bot().get_exchange_traders().values():
         if trader.is_enabled():
             at_least_one = True
-            get_bot().run_in_main_asyncio_loop(trader.force_refresh_portfolio())
-            get_bot().run_in_main_asyncio_loop(trader.force_refresh_orders())
+            get_bot().run_in_main_asyncio_loop(trader.force_refresh_orders_and_portfolio())
 
     if not at_least_one:
         raise RuntimeError("no real trader to update.")

--- a/octobot.py
+++ b/octobot.py
@@ -203,7 +203,7 @@ class OctoBot:
                         # notify that exchange doesn't support this symbol
                         else:
                             if not self.backtesting_enabled:
-                                self.logger.warning(f"{exchange.get_name()} doesn't support {symbol}")
+                                self.logger.error(f"{exchange.get_name()} doesn't support {symbol}")
 
         self._check_required_evaluators()
 

--- a/trading/exchanges/exchange_exceptions.py
+++ b/trading/exchanges/exchange_exceptions.py
@@ -1,0 +1,21 @@
+#  Drakkar-Software OctoBot
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+
+
+class MissingOrderException(Exception):
+
+    def __init__(self, order_id):
+        self.order_id = order_id

--- a/trading/trader/modes/abstract_mode_decider.py
+++ b/trading/trader/modes/abstract_mode_decider.py
@@ -131,8 +131,7 @@ class AbstractTradingModeDecider:
                         if not trader.get_simulate():
                             try:
                                 # second chance: force portfolio update and retry
-                                await trader.force_refresh_portfolio(pf)
-                                await trader.force_refresh_orders(pf)
+                                await trader.force_refresh_orders_and_portfolio(pf)
                                 new_orders = await order_creator.create_new_order(
                                     self.final_eval,
                                     self.symbol,

--- a/trading/trader/trader.py
+++ b/trading/trader/trader.py
@@ -207,6 +207,8 @@ class Trader(Initializable):
                                                              new_order.get_origin_price(),
                                                              new_order.origin_stop_price)
 
+            self.logger.info(f"Created order on {self.exchange.get_name()}: {created_order}")
+
             # get real order from exchange
             new_order = self.parse_exchange_order_to_order_instance(created_order)
 
@@ -377,6 +379,10 @@ class Trader(Initializable):
                 order = self.parse_exchange_order_to_order_instance(open_order)
                 async with self.portfolio.get_lock():
                     await self.create_order(order, self.portfolio, True)
+
+    async def force_refresh_orders_and_portfolio(self, portfolio=None):
+        await self.force_refresh_portfolio(portfolio)
+        await self.force_refresh_orders(portfolio)
 
     async def force_refresh_portfolio(self, portfolio=None):
         if not self.simulate:


### PR DESCRIPTION
Now logs order details on creation, try to download order when missing from database and if it still doesn't work, force trader resync.

order creation log:
Trader               Created order on binance: {'info': {'symbol': 'ADABTC', 'orderId': 83540271, 'clientOrderId': 'FSFAEA5S15Q4S54KI4', 'transactTime': 1550874781847, 'price': '0.00001169', 'origQty': '132.00000000', 'executedQty': '0.00000000', 'cummulativeQuoteQty': '0.00000000', 'status': 'NEW', 'timeInForce': 'GTC', 'type': 'LIMIT', 'side': 'SELL'}, 'id': '83540271', 'timestamp': 1550874781847, 'datetime': '2019-02-22T22:33:01.847Z', 'lastTradeTimestamp': None, 'symbol': 'ADA/BTC', 'type': 'limit', 'side': 'sell', 'price': 1.169e-05, 'amount': 132.0, 'cost': 0.0, 'average': None, 'filled': 0.0, 'remaining': 132.0, 'status': 'open', 'fee': None, 'trades': None}
