### PR TITLE
portfolio pie chart now start with blue

### DIFF
--- a/interfaces/web/static/js/common/cst.js
+++ b/interfaces/web/static/js/common/cst.js
@@ -64,8 +64,8 @@ const trading_config_type = "trading_config";
 
 const max_attempts = 20;
 
-const material_colors = ["#d50000", "#6200ea", "#2962ff", "#00b8d4", "#00c853", "#aeea00", "#ffab00",
-    "#dd2c00"];
+const material_colors = ["#2962ff", "#00b8d4", "#00c853", "#aeea00", "#ffab00",
+    "#dd2c00", "#d50000", "#6200ea"];
 
-const material_dark_colors = ["#9b0000", "#0a00b6", "#0039cb", "#0088a3", "#009624", "#79b700", "#c67c00",
-    "#a30000"];
+const material_dark_colors = ["#0039cb", "#0088a3", "#009624", "#79b700", "#c67c00",
+    "#a30000", "#9b0000", "#0a00b6"];

--- a/interfaces/web/static/js/common/util.js
+++ b/interfaces/web/static/js/common/util.js
@@ -21,12 +21,12 @@ function setup_editable(){
 }
 
 function get_color(index){
-    let color_index = index % (material_colors.length-1);
+    let color_index = index % (material_colors.length);
     return material_colors[color_index];
 }
 
 function get_dark_color(index){
-    let color_index = index % (material_dark_colors.length-1);
+    let color_index = index % (material_dark_colors.length);
     return material_dark_colors[color_index];
 }
 


### PR DESCRIPTION
few currencies:
before:
![image](https://user-images.githubusercontent.com/9078616/54085727-4b7e1480-4341-11e9-87b0-ad8a4aa56ec0.png)
after:
![image](https://user-images.githubusercontent.com/9078616/54085740-7d8f7680-4341-11e9-8f62-3a673830ecf6.png)


many currencies:
before:
![image](https://user-images.githubusercontent.com/9078616/54085708-1f629380-4341-11e9-8c33-d6055255dfc2.png)
after:
![image](https://user-images.githubusercontent.com/9078616/54085697-0659e280-4341-11e9-9b8e-af864e262239.png)

=> blue is less aggressive than red, therefore better as a first color

also fixed color picker algo to use all colors