### PR TITLE
added identifier to simulator order manager logs

### DIFF
--- a/trading/trader/orders_manager.py
+++ b/trading/trader/orders_manager.py
@@ -40,7 +40,7 @@ class OrdersManager:
         self.trader = trader
         self.order_list = []
         self.last_symbol_prices = {}
-        self.logger = get_logger(self.__class__.__name__)
+        self.logger = get_logger(f"{self.__class__.__name__}{'Simulator' if self.trader.simulate else ''}")
 
         if self.trader.get_exchange().is_web_socket_available():
             self.order_refresh_time = ORDER_REFRESHER_TIME_WS


### PR DESCRIPTION
Will now be easy to differenciate the 2 order managers per exchange when looking at logs