### PR TITLE
WIP Feature/trader persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,5 @@ config\.json
 *.ods
 temp_config\.json
 log
+
+config/trading_state_history\.json

--- a/backtesting/__init__.py
+++ b/backtesting/__init__.py
@@ -13,3 +13,16 @@
 #
 #  You should have received a copy of the GNU Lesser General Public
 #  License along with this library.
+
+
+from config import CONFIG_BACKTESTING, CONFIG_ENABLED_OPTION
+
+
+def backtesting_enabled(config):
+    return CONFIG_BACKTESTING in config and config[CONFIG_BACKTESTING][CONFIG_ENABLED_OPTION]
+
+
+class BacktestingEndedException(Exception):
+    def __init__(self, symbol=""):
+        self.msg = f"Backtesting finished for {symbol}."
+        super().__init__(self.msg)

--- a/backtesting/backtesting.py
+++ b/backtesting/backtesting.py
@@ -180,15 +180,5 @@ class Backtesting:
         return market_delta
 
     @staticmethod
-    def enabled(config):
-        return CONFIG_BACKTESTING in config and config[CONFIG_BACKTESTING][CONFIG_ENABLED_OPTION]
-
-    @staticmethod
     def analysis_enabled(config):
         return CONFIG_BACKTESTING in config and config[CONFIG_BACKTESTING][CONFIG_ANALYSIS_ENABLED_OPTION]
-
-
-class BacktestingEndedException(Exception):
-    def __init__(self, symbol=""):
-        self.msg = f"Backtesting finished for {symbol}."
-        super().__init__(self.msg)

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -117,6 +117,19 @@ MARKET_SEPARATOR = "/"
 CURRENCY_DEFAULT_MAX_PRICE_DIGITS = 8
 EXCHANGE_ERROR_SLEEPING_TIME = 10
 
+# Trader persistence
+HISTORY_EXCHANGE_KEY = "exchange"
+SIMULATOR_INITIAL_STARTUP_PORTFOLIO = "simulator_initial_portfolio"
+REAL_INITIAL_STARTUP_PORTFOLIO = "real_initial_portfolio"
+SIMULATOR_CURRENT_PORTFOLIO = "simulator_current_portfolio"
+SIMULATOR_TRADE_HISTORY = "simulator_trades_history"
+REAL_TRADE_HISTORY = "real_trades_history"
+SIMULATOR_INITIAL_STARTUP_PORTFOLIO_VALUE = "simulator_initial_portfolio_value"
+REAL_INITIAL_STARTUP_PORTFOLIO_VALUE = "real_initial_portfolio_value"
+SIMULATOR_REFERENCE_MARKET = "reference_market"
+WATCHED_MARKETS_INITIAL_STARTUP_VALUES = "initial_watched_markets_value"
+
+
 # Exchanges
 TESTED_EXCHANGES = ["binance"]
 SIMULATOR_TESTED_EXCHANGES = ["bitfinex", "bittrex", "coinbasepro", "kraken", "poloniex", "cryptopia", "bitmex"]
@@ -257,10 +270,12 @@ CONFIG_EVALUATOR_FILE = "evaluator_config.json"
 CONFIG_TRADING_FILE = "trading_config.json"
 CONFIG_EVALUATOR_FILE_PATH = f"{TENTACLES_PATH}/{TENTACLES_EVALUATOR_PATH}/{CONFIG_EVALUATOR_FILE}"
 CONFIG_TRADING_FILE_PATH = f"{TENTACLES_PATH}/{TENTACLES_TRADING_PATH}/{CONFIG_TRADING_FILE}"
-CONFIG_DEFAULT_EVALUATOR_FILE = "config/default_evaluator_config.json"
-CONFIG_DEFAULT_TRADING_FILE = "config/default_trading_config.json"
-DEFAULT_CONFIG_FILE = "config/default_config.json"
-LOGGING_CONFIG_FILE = "config/logging_config.ini"
+CONFIG_FOLDER = "config"
+CONFIG_DEFAULT_EVALUATOR_FILE = f"{CONFIG_FOLDER}/default_evaluator_config.json"
+CONFIG_DEFAULT_TRADING_FILE = f"{CONFIG_FOLDER}/default_trading_config.json"
+DEFAULT_CONFIG_FILE = f"{CONFIG_FOLDER}/default_config.json"
+LOGGING_CONFIG_FILE = f"{CONFIG_FOLDER}/logging_config.ini"
+SIMULATOR_STATE_SAVE_FILE = f"{CONFIG_FOLDER}/trading_state_history.json"
 
 # Tentacle Config
 STRATEGIES_REQUIRED_TIME_FRAME = "required_time_frames"

--- a/config/config.py
+++ b/config/config.py
@@ -44,7 +44,7 @@ def load_config(config_file=CONFIG_FILE, error=True):
         else:
             logger.error(error_str)
     except Exception as e:
-        error_str = "{0} : {1}".format(basic_error, e)
+        error_str = f"{basic_error} : {e}"
         if error:
             raise Exception(error_str)
         else:
@@ -56,7 +56,7 @@ def init_config(config_file=CONFIG_FILE, from_config_file=DEFAULT_CONFIG_FILE):
     try:
         copyfile(from_config_file, config_file)
     except Exception as e:
-        raise Exception("Can't init config file {0}".format(e))
+        raise Exception(f"Can't init config file {e}")
 
 
 def is_config_empty_or_missing(config_file=CONFIG_FILE):

--- a/evaluator/RealTime/realtime_evaluator.py
+++ b/evaluator/RealTime/realtime_evaluator.py
@@ -19,7 +19,7 @@ import time
 import os
 from abc import *
 
-from backtesting.backtesting import Backtesting
+from backtesting import backtesting_enabled
 from config.config import load_config
 from config import CONFIG_EVALUATOR_REALTIME, CONFIG_REFRESH_RATE, PriceIndexes, MIN_EVAL_TIME_FRAME, \
     DEFAULT_WEBSOCKET_REAL_TIME_EVALUATOR_REFRESH_RATE_SECONDS, DEFAULT_REST_REAL_TIME_EVALUATOR_REFRESH_RATE_SECONDS, \
@@ -96,7 +96,7 @@ class RealTimeEvaluator(AbstractEvaluator):
                 if self._should_eval():
                     await self.eval()
 
-            if not Backtesting.enabled(self.config):
+            if not backtesting_enabled(self.config):
                 sleeping_time = self.specific_config[CONFIG_REFRESH_RATE] - (time.time() - now)
                 if sleeping_time > 0:
                     await asyncio.sleep(sleeping_time)

--- a/evaluator/Updaters/global_price_updater.py
+++ b/evaluator/Updaters/global_price_updater.py
@@ -20,7 +20,7 @@ import copy
 from concurrent.futures import CancelledError
 
 from tools.logging.logging_util import get_logger
-from backtesting.backtesting import Backtesting, BacktestingEndedException
+from backtesting import BacktestingEndedException, backtesting_enabled
 from config import TimeFramesMinutes, MINUTE_TO_SECONDS, UPDATER_MAX_SLEEPING_TIME
 from tools.time_frame_manager import TimeFrameManager
 
@@ -194,12 +194,12 @@ class GlobalPriceUpdater:
             self.evaluator_task_manager_by_time_frame_by_symbol[time_frames[0]][self.symbols[0]]
 
         # test if we need to initialize backtesting features
-        backtesting_enabled = Backtesting.enabled(evaluator_task_manager.get_evaluator().get_config())
-        if backtesting_enabled:
+        is_backtesting_enabled = backtesting_enabled(evaluator_task_manager.get_evaluator().get_config())
+        if is_backtesting_enabled:
             for symbol in self.symbols:
                 self.exchange.get_exchange().init_candles_offset(time_frames, symbol)
 
-        return backtesting_enabled
+        return is_backtesting_enabled
 
     def stop(self):
         self.keep_running = False

--- a/evaluator/cryptocurrency_evaluator.py
+++ b/evaluator/cryptocurrency_evaluator.py
@@ -16,7 +16,7 @@
 
 from tools.logging.logging_util import get_logger
 
-from backtesting.backtesting import Backtesting
+from backtesting import backtesting_enabled
 from evaluator.Updaters.social_evaluator_not_tasked_update_task import SocialEvaluatorNotTaskedUpdateTask
 from evaluator.evaluator_creator import EvaluatorCreator
 from config import CONFIG_EVALUATORS_WILDCARD
@@ -32,7 +32,7 @@ class CryptocurrencyEvaluator:
 
         self.symbol_evaluator_list = {}
 
-        if Backtesting.enabled(self.config):
+        if backtesting_enabled(self.config):
             self.social_eval_list = []
             self.social_not_tasked_list = []
         else:

--- a/interfaces/web/controllers/configuration.py
+++ b/interfaces/web/controllers/configuration.py
@@ -23,7 +23,7 @@ from interfaces.web import server_instance
 from interfaces.web.models.configuration import get_strategy_config, update_evaluator_config, \
     get_evaluator_startup_config, get_services_list, get_symbol_list, update_global_config, get_all_symbol_list, \
     get_tested_exchange_list, get_simulated_exchange_list, get_other_exchange_list, get_edited_config, \
-    update_trading_config, get_trading_startup_config
+    update_trading_config, get_trading_startup_config, reset_trading_history
 from interfaces.web.util.flask_util import get_rest_reply
 
 
@@ -101,6 +101,19 @@ def config():
                                evaluator_startup_config=get_evaluator_startup_config(),
                                trading_startup_config=get_trading_startup_config()
                                )
+
+
+@server_instance.route('/config_actions', methods=['POST'])
+def config_actions():
+    action = request.args.get("action")
+    if action == "reset_trading_history":
+        reset_trading_history()
+        return jsonify({
+            "title": "Trading history reset",
+            "details": "Next trading sessions will not consider past sessions for "
+                       "profitability and trading simulator will start using a fresh portfolio."
+            })
+    return get_rest_reply("No specified action.", code=500)
 
 
 @server_instance.template_filter()

--- a/interfaces/web/controllers/trading.py
+++ b/interfaces/web/controllers/trading.py
@@ -102,7 +102,7 @@ def utility_processor():
     def convert_timestamp(str_time):
         return datetime.datetime.fromtimestamp(str_time).strftime('%Y-%m-%d %H:%M:%S')
 
-    def convert_type(str_type):
-        return str(str_type).replace("TraderOrderType.", "")
+    def convert_type(order_type):
+        return order_type.name
 
     return dict(convert_timestamp=convert_timestamp, convert_type=convert_type)

--- a/interfaces/web/models/configuration.py
+++ b/interfaces/web/models/configuration.py
@@ -30,7 +30,7 @@ from services import NotifierService
 from tools.config_manager import ConfigManager
 from tools.class_inspector import get_class_from_string, evaluator_parent_inspection, trading_mode_parent_inspection
 from evaluator.abstract_evaluator import AbstractEvaluator
-from backtesting.backtesting import Backtesting
+from backtesting import backtesting_enabled
 
 
 def get_edited_config():
@@ -51,6 +51,10 @@ def _get_trading_config():
 
 def get_trading_startup_config():
     return get_bot().get_startup_config()[CONFIG_TRADING_TENTACLES]
+
+
+def reset_trading_history():
+    get_bot().get_previous_trading_state_manager().reset_trading_history()
 
 
 def _get_advanced_class_details(class_name, klass, is_trading_mode=False, is_strategy=False):
@@ -179,7 +183,7 @@ def get_strategy_config():
 
 
 def get_in_backtesting_mode():
-    return Backtesting.enabled(get_bot().get_config())
+    return backtesting_enabled(get_bot().get_config())
 
 
 def _fill_evaluator_config(evaluator_name, activated, eval_type_key,

--- a/interfaces/web/models/dashboard.py
+++ b/interfaces/web/models/dashboard.py
@@ -14,7 +14,7 @@
 #  You should have received a copy of the GNU Lesser General Public
 #  License along with this library.
 
-from backtesting.backtesting import Backtesting
+from backtesting import backtesting_enabled
 from config import TimeFrames, PriceIndexes, PriceStrings, BOT_TOOLS_BACKTESTING
 from interfaces import get_bot, get_default_time_frame, get_global_config
 from interfaces.web import add_to_symbol_data_history, \
@@ -184,7 +184,7 @@ def get_currency_price_graph_update(exchange_name, symbol, time_frame, list_arra
         bot = bot.get_tools()[BOT_TOOLS_BACKTESTING].get_bot()
     symbol = parse_get_symbol(symbol)
     symbol_evaluator_list = bot.get_symbol_evaluator_list()
-    in_backtesting = Backtesting.enabled(get_global_config()) or backtesting
+    in_backtesting = backtesting_enabled(get_global_config()) or backtesting
 
     exchange = exchange_name
     exchange_list = bot.get_exchanges_list()

--- a/interfaces/web/static/js/common/util.js
+++ b/interfaces/web/static/js/common/util.js
@@ -82,3 +82,16 @@ function check_has_event_using_handler(elem, event_type, handler){
     });
     return has_events;
 }
+
+function generic_request_success_callback(updated_data, update_url, dom_root_element, msg, status) {
+    if(msg.hasOwnProperty("title")){
+        create_alert("success", msg["title"], msg["details"]);
+    }else{
+        create_alert("success", msg, "");
+    }
+
+}
+
+function generic_request_failure_callback(updated_data, update_url, dom_root_element, msg, status) {
+    create_alert("error", msg.responseText, "");
+}

--- a/interfaces/web/static/js/components/configuration.js
+++ b/interfaces/web/static/js/components/configuration.js
@@ -47,6 +47,14 @@ function handle_remove_buttons(){
     });
 }
 
+function handle_buttons() {
+    $("button[action=post]").each(function () {
+        $(this).click(function () {
+            send_and_interpret_bot_update(null, $(this).attr(update_url_attr), null, generic_request_success_callback, generic_request_failure_callback);
+        });
+    });
+}
+
 function check_deck_modifications(deck){
     if(deck.find("."+added_class).length > 0 || deleted_global_config_elements.length > 0){
         toogle_deck_container_modified(deck);
@@ -482,6 +490,8 @@ $(document).ready(function() {
 
     handle_add_buttons();
     handle_remove_buttons();
+    
+    handle_buttons();
 
     handle_evaluator_configuration_editor();
 

--- a/interfaces/web/templates/components/config/trader_card.html
+++ b/interfaces/web/templates/components/config/trader_card.html
@@ -1,5 +1,5 @@
 {% import 'components/config/editable_config.html' as m_editable_config %}
-{% macro config_trader_card(config, config_name, trader, add_class='', link='') -%}
+{% macro config_trader_card(config, config_name, trader, add_class='', link='', action=None) -%}
     <!-- Card -->
     <div class="card mb-4 {{add_class}} config-card">
 
@@ -25,6 +25,11 @@
                                                         config[key])
                     }}
                 {% endfor %}
+                {% if action %}
+                    <div class="text-center">
+                        <button class="btn btn-warning waves-effect" type="button" action="post" update-url="{{ action[1] }}">{{ action[0] }}</button>
+                    </div>
+                {% endif %}
             </p>
         </div>
     </div>

--- a/interfaces/web/templates/config.html
+++ b/interfaces/web/templates/config.html
@@ -152,7 +152,7 @@
                  <!-- Card deck -->
                 <div class="card-deck config-container">
                     <span class="col-lg-12">
-                        {{ m_config_trader_card.config_trader_card(config_trading, "trading", "Trading settings", link="https://github.com/Drakkar-Software/OctoBot/wiki/Trader#trading-settings") }}
+                        {{ m_config_trader_card.config_trader_card(config_trading, "trading", "Trading settings", link="https://github.com/Drakkar-Software/OctoBot/wiki/Trader#trading-settings", action=("Reset trading history", url_for("config_actions", action="reset_trading_history"))) }}
                     </span>
                     {{ m_config_trader_card.config_trader_card(config_trader, "trader", "Trader", link="https://github.com/Drakkar-Software/OctoBot/wiki/Trader#trader") }}
                     {{ m_config_trader_card.config_trader_card(config_trader_simulator, "trader-simulator", "Trader simulator", link="https://github.com/Drakkar-Software/OctoBot/wiki/Simulator#simulator") }}

--- a/services/abstract_service.py
+++ b/services/abstract_service.py
@@ -16,7 +16,7 @@
 
 from abc import ABCMeta, abstractmethod
 
-from backtesting.backtesting import Backtesting
+from backtesting import backtesting_enabled
 from tools.config_manager import ConfigManager
 
 
@@ -64,7 +64,7 @@ class AbstractService:
 
     @classmethod
     def should_be_ready(cls, config):
-        on_backtesting = Backtesting.enabled(config)
+        on_backtesting = backtesting_enabled(config)
         return not on_backtesting or (on_backtesting and cls.BACKTESTING_ENABLED)
 
     # Used to provide a new logger for this particular indicator

--- a/start.py
+++ b/start.py
@@ -160,7 +160,9 @@ def start_octobot(starting_args):
 
                     update_config_with_args(starting_args, config)
 
-                    bot = OctoBot(config)
+                    reset_trading_history = starting_args.reset_trading_history
+
+                    bot = OctoBot(config, reset_trading_history=reset_trading_history)
 
                     import interfaces
                     interfaces.__init__(bot, config)
@@ -204,6 +206,11 @@ def main(args=None):
     parser.add_argument('-v', '--version', help='Show OctoBot current version.',
                         action='store_true')
     parser.add_argument('-s', '--simulate', help='Force OctoBot to start with the trader simulator only.',
+                        action='store_true')
+    parser.add_argument('-rts', '--reset-trading-history', help='Force the traders to reset their history. They will '
+                                                                'now take the next portfolio as a reference for '
+                                                                'profitability and trading simulators will use a '
+                                                                'fresh new portfolio.',
                         action='store_true')
     parser.add_argument('-d', '--data_collector',
                         help='Start the data collector process to store data for backtesting.',

--- a/tests/static/trading_states_tests/ok_ref.json
+++ b/tests/static/trading_states_tests/ok_ref.json
@@ -1,0 +1,36 @@
+{
+ "ExchangeSimulator['BTC/USDT', 'ETH/USDT', 'ICX/BTC', 'NEO/BTC', 'VEN/BTC', 'XRB/BTC', 'ONT/BTC', 'XLM/BTC', 'POWR/BTC', 'ADA/BTC', 'ETC/BTC', 'WAX/BTC', 'XRP/BTC', 'XVG/BTC']": {
+  "simulator_initial_portfolio": {
+   "BTC": 10,
+   "USD": 1000
+  },
+  "real_initial_portfolio": {},
+  "simulator_current_portfolio": {
+   "BTC": 10,
+   "USD": 1000
+  },
+  "simulator_trades_history": [],
+  "real_trades_history": [],
+  "simulator_initial_portfolio_value": 10,
+  "real_initial_portfolio_value": 0,
+  "initial_watched_markets_value": {
+    "BTC": 1,
+    "USDT": 0.00025075791580050704,
+	"XLM": 10,
+	"ETC": 10,
+	"XRB": 10,
+	"VEN": 10,
+	"ONT": 10,
+	"XRP": 10,
+	"NEO": 10,
+	"ADA": 10,
+	"EUR": 10,
+	"POWR": 10,
+	"WAX": 10,
+	"ICX": 10,
+	"XVG": 10,
+	"ETH": 10
+  },
+  "reference_market": "BTC"
+ }
+}

--- a/tests/test_utils/config.py
+++ b/tests/test_utils/config.py
@@ -18,6 +18,9 @@ from config.config import load_config
 from config import CONFIG_EVALUATOR, CONFIG_TRADING_TENTACLES, TimeFrames, CONFIG_TIME_FRAME
 
 
+TEST_CONFIG_FOLDER = "tests/static"
+
+
 def init_config_time_frame_for_tests(config):
     result = []
     for time_frame in config[CONFIG_TIME_FRAME]:
@@ -26,8 +29,8 @@ def init_config_time_frame_for_tests(config):
 
 
 def load_test_config():
-    config = load_config("tests/static/config.json")
-    config[CONFIG_EVALUATOR] = load_config("tests/static/evaluator_config.json", False)
-    config[CONFIG_TRADING_TENTACLES] = load_config("tests/static/trading_config.json", False)
+    config = load_config(f"{TEST_CONFIG_FOLDER}/config.json")
+    config[CONFIG_EVALUATOR] = load_config(f"{TEST_CONFIG_FOLDER}/evaluator_config.json", False)
+    config[CONFIG_TRADING_TENTACLES] = load_config(f"{TEST_CONFIG_FOLDER}/trading_config.json", False)
     init_config_time_frame_for_tests(config)
     return config

--- a/tests/unit_tests/trading_tests/test_exchange_simulator.py
+++ b/tests/unit_tests/trading_tests/test_exchange_simulator.py
@@ -23,7 +23,6 @@ from config import CONFIG_ENABLED_OPTION, CONFIG_BACKTESTING, TimeFrames, HOURS_
 from tests.test_utils.config import load_test_config
 from trading.exchanges.exchange_manager import ExchangeManager
 from trading.trader.trader_simulator import TraderSimulator
-from trading.trader.order import OrderConstants
 
 
 # All test coroutines will be treated as marked.
@@ -107,23 +106,19 @@ class TestExchangeSimulator:
             CONFIG_SIMULATOR_FEES_TAKER: 0.1
         }
 
-        buy_market_fee = exchange_inst.get_trade_fee("BTC/USD",
-                                                     OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_MARKET],
+        buy_market_fee = exchange_inst.get_trade_fee("BTC/USD", TraderOrderType.BUY_MARKET,
                                                      10, 100, ExchangeConstantsMarketPropertyColumns.TAKER.value)
         self._assert_fee(buy_market_fee, "BTC", 0.01, 0.001, ExchangeConstantsMarketPropertyColumns.TAKER.value)
 
         sell_market_fee = exchange_inst.get_trade_fee(
-            "BTC/USD",  OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_MARKET],
-            10, 100, ExchangeConstantsMarketPropertyColumns.TAKER.value)
+            "BTC/USD",  TraderOrderType.SELL_MARKET, 10, 100, ExchangeConstantsMarketPropertyColumns.TAKER.value)
         self._assert_fee(sell_market_fee, "USD", 1, 0.001, ExchangeConstantsMarketPropertyColumns.TAKER.value)
 
-        buy_limit_fee = exchange_inst.get_trade_fee("BTC/USD",
-                                                    OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        buy_limit_fee = exchange_inst.get_trade_fee("BTC/USD", TraderOrderType.BUY_LIMIT,
                                                     10, 100, ExchangeConstantsMarketPropertyColumns.MAKER.value)
         self._assert_fee(buy_limit_fee, "BTC", 0.005, 0.0005, ExchangeConstantsMarketPropertyColumns.MAKER.value)
 
-        sell_limit_fee = exchange_inst.get_trade_fee("BTC/USD",
-                                                     OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        sell_limit_fee = exchange_inst.get_trade_fee("BTC/USD", TraderOrderType.SELL_LIMIT,
                                                      10, 100, ExchangeConstantsMarketPropertyColumns.TAKER.value)
         self._assert_fee(sell_limit_fee, "USD", 1, 0.001, ExchangeConstantsMarketPropertyColumns.TAKER.value)
 

--- a/tests/unit_tests/trading_tests/test_order.py
+++ b/tests/unit_tests/trading_tests/test_order.py
@@ -23,7 +23,7 @@ import ccxt
 from trading.exchanges.exchange_manager import ExchangeManager
 from config import TradeOrderSide, SIMULATOR_LAST_PRICES_TO_CHECK, TraderOrderType, OrderStatus
 from tests.test_utils.config import load_test_config
-from trading.trader.order import Order, OrderConstants
+from trading.trader.order import Order
 from trading.trader.trader_simulator import TraderSimulator
 
 
@@ -151,7 +151,7 @@ class TestOrder:
         config, order_inst, trader_inst, exchange_inst = await self.init_default()
 
         # with real trader
-        order_inst.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_MARKET],
+        order_inst.new(TraderOrderType.BUY_MARKET,
                        "BTC/USDT",
                        10000,
                        1,
@@ -159,7 +159,7 @@ class TestOrder:
                        stop_price=None,
                        order_notifier=None)
 
-        assert order_inst.get_order_type() == OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_MARKET]
+        assert order_inst.get_order_type() == TraderOrderType.BUY_MARKET
         assert order_inst.get_order_symbol() == "BTC/USDT"
         assert order_inst.get_create_last_price() == 10000
         assert order_inst.get_origin_quantity() == 1
@@ -168,7 +168,7 @@ class TestOrder:
         assert order_inst.get_side() is None
         assert order_inst.get_status() == OrderStatus.OPEN
 
-        order_inst.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.STOP_LOSS_LIMIT],
+        order_inst.new(TraderOrderType.STOP_LOSS_LIMIT,
                        "ETH/BTC",
                        0.1,
                        5.2,
@@ -183,7 +183,7 @@ class TestOrder:
         trader_sim_inst = TraderSimulator(config, exchange_inst, 1)
         order_sim_inst = Order(trader_sim_inst)
 
-        order_sim_inst.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_MARKET],
+        order_sim_inst.new(TraderOrderType.SELL_MARKET,
                            "LTC/USDT",
                            100,
                            3.22,

--- a/tests/unit_tests/trading_tests/test_portfolio.py
+++ b/tests/unit_tests/trading_tests/test_portfolio.py
@@ -48,9 +48,19 @@ class TestPortfolio:
     async def test_load_portfolio(self):
         _, portfolio_inst, _, _ = await self.init_default()
         await portfolio_inst._load_portfolio()
-        assert portfolio_inst.portfolio == {'BTC': {'available': 10, 'total': 10},
-                                            'USD': {'available': 1000, 'total': 1000}
-                                            }
+        assert portfolio_inst.portfolio == {
+            'BTC': {'available': 10, 'total': 10},
+            'USD': {'available': 1000, 'total': 1000}
+        }
+
+    async def test_get_portfolio_from_amount_dict(self):
+        assert Portfolio.get_portfolio_from_amount_dict({"zyx": 10, "BTC": 1}) == {
+            'zyx': {'available': 10, 'total': 10},
+            'BTC': {'available': 1, 'total': 1}
+        }
+        assert Portfolio.get_portfolio_from_amount_dict({}) == {}
+        with pytest.raises(RuntimeError):
+            Portfolio.get_portfolio_from_amount_dict({"zyx": "10", "BTC": 1})
 
     async def test_get_currency_portfolio(self):
         _, portfolio_inst, _, _ = await self.init_default()

--- a/tests/unit_tests/trading_tests/test_portfolio.py
+++ b/tests/unit_tests/trading_tests/test_portfolio.py
@@ -22,7 +22,7 @@ from config import TraderOrderType, CONFIG_SIMULATOR, CONFIG_SIMULATOR_FEES, CON
 from tests.test_utils.config import load_test_config
 from tests.test_utils.order_util import fill_limit_or_stop_order, fill_market_order
 from trading.exchanges.exchange_manager import ExchangeManager
-from trading.trader.order import BuyMarketOrder, OrderConstants, SellLimitOrder, BuyLimitOrder, SellMarketOrder, \
+from trading.trader.order import BuyMarketOrder, SellLimitOrder, BuyLimitOrder, SellMarketOrder, \
     StopLossOrder
 from trading.trader.portfolio import Portfolio
 from trading.trader.trader_simulator import TraderSimulator
@@ -72,7 +72,7 @@ class TestPortfolio:
 
         # Test buy order
         market_buy = BuyMarketOrder(trader_inst)
-        market_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_MARKET],
+        market_buy.new(TraderOrderType.BUY_MARKET,
                        "BTC/USD",
                        70,
                        10,
@@ -93,7 +93,7 @@ class TestPortfolio:
 
         # Test sell order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "BTC/USD",
                        60,
                        8,
@@ -117,7 +117,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_buy = BuyLimitOrder(trader_inst)
-        limit_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy.new(TraderOrderType.BUY_LIMIT,
                       "BTC/USD",
                       70,
                       10,
@@ -138,7 +138,7 @@ class TestPortfolio:
 
         # Test buy order
         market_sell = SellMarketOrder(trader_inst)
-        market_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_MARKET],
+        market_sell.new(TraderOrderType.SELL_MARKET,
                         "BTC/USD",
                         80,
                         8,
@@ -169,7 +169,7 @@ class TestPortfolio:
 
         # Test buy order
         market_sell = SellMarketOrder(trader_inst)
-        market_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_MARKET],
+        market_sell.new(TraderOrderType.SELL_MARKET,
                         "BTC/USD",
                         70,
                         3,
@@ -179,7 +179,7 @@ class TestPortfolio:
 
         # Test sell order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "BTC/USD",
                        100,
                        4.2,
@@ -187,7 +187,7 @@ class TestPortfolio:
 
         # Test stop loss order
         stop_loss = StopLossOrder(trader_inst)
-        stop_loss.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.STOP_LOSS],
+        stop_loss.new(TraderOrderType.STOP_LOSS,
                       "BTC/USD",
                       80,
                       4.2,
@@ -198,7 +198,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_buy = BuyLimitOrder(trader_inst)
-        limit_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy.new(TraderOrderType.BUY_LIMIT,
                       "BTC/USD",
                       50,
                       2,
@@ -249,7 +249,7 @@ class TestPortfolio:
 
         # Test buy order
         market_sell = SellMarketOrder(trader_inst)
-        market_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_MARKET],
+        market_sell.new(TraderOrderType.SELL_MARKET,
                         "BTC/USD",
                         80,
                         4.1,
@@ -257,7 +257,7 @@ class TestPortfolio:
 
         # Test sell order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "BTC/USD",
                        10,
                        4.2,
@@ -265,7 +265,7 @@ class TestPortfolio:
 
         # Test stop loss order
         stop_loss = StopLossOrder(trader_inst)
-        stop_loss.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.STOP_LOSS],
+        stop_loss.new(TraderOrderType.STOP_LOSS,
                       "BTC/USD",
                       80,
                       3.6,
@@ -276,7 +276,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_buy = BuyLimitOrder(trader_inst)
-        limit_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy.new(TraderOrderType.BUY_LIMIT,
                       "BTC/USD",
                       50,
                       4,
@@ -306,7 +306,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "BTC/USD",
                        90,
                        4,
@@ -314,7 +314,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_buy = BuyLimitOrder(trader_inst)
-        limit_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy.new(TraderOrderType.BUY_LIMIT,
                       "BTC/USD",
                       50,
                       4,
@@ -322,7 +322,7 @@ class TestPortfolio:
 
         # Test stop loss order
         stop_loss = StopLossOrder(trader_inst)
-        stop_loss.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.STOP_LOSS],
+        stop_loss.new(TraderOrderType.STOP_LOSS,
                       "BTC/USD",
                       60,
                       4,
@@ -357,7 +357,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "BTC/USD",
                        90,
                        4,
@@ -365,7 +365,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_buy = BuyLimitOrder(trader_inst)
-        limit_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy.new(TraderOrderType.BUY_LIMIT,
                       "BTC/USD",
                       60,
                       2,
@@ -373,7 +373,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_buy_2 = BuyLimitOrder(trader_inst)
-        limit_buy_2.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy_2.new(TraderOrderType.BUY_LIMIT,
                         "BTC/USD",
                         50,
                         4,
@@ -381,7 +381,7 @@ class TestPortfolio:
 
         # Test sell order
         limit_sell_2 = SellLimitOrder(trader_inst)
-        limit_sell_2.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell_2.new(TraderOrderType.SELL_LIMIT,
                          "BTC/USD",
                          10,
                          2,
@@ -389,7 +389,7 @@ class TestPortfolio:
 
         # Test stop loss order
         stop_loss_2 = StopLossOrder(trader_inst)
-        stop_loss_2.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.STOP_LOSS],
+        stop_loss_2.new(TraderOrderType.STOP_LOSS,
                         "BTC/USD",
                         10,
                         2,
@@ -397,7 +397,7 @@ class TestPortfolio:
 
         # Test sell order
         limit_sell_3 = SellLimitOrder(trader_inst)
-        limit_sell_3.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell_3.new(TraderOrderType.SELL_LIMIT,
                          "BTC/USD",
                          20,
                          1,
@@ -405,7 +405,7 @@ class TestPortfolio:
 
         # Test stop loss order
         stop_loss_3 = StopLossOrder(trader_inst)
-        stop_loss_3.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.STOP_LOSS],
+        stop_loss_3.new(TraderOrderType.STOP_LOSS,
                         "BTC/USD",
                         20,
                         1,
@@ -450,7 +450,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "BTC/USD",
                        90,
                        4,
@@ -458,7 +458,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_buy = BuyLimitOrder(trader_inst)
-        limit_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy.new(TraderOrderType.BUY_LIMIT,
                       "BTC/USD",
                       60,
                       2,
@@ -466,7 +466,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_buy_2 = BuyLimitOrder(trader_inst)
-        limit_buy_2.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy_2.new(TraderOrderType.BUY_LIMIT,
                         "BTC/USD",
                         50,
                         4,
@@ -474,7 +474,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_buy_3 = BuyLimitOrder(trader_inst)
-        limit_buy_3.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy_3.new(TraderOrderType.BUY_LIMIT,
                         "BTC/USD",
                         46,
                         2,
@@ -482,7 +482,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_buy_4 = BuyLimitOrder(trader_inst)
-        limit_buy_4.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy_4.new(TraderOrderType.BUY_LIMIT,
                         "BTC/USD",
                         41,
                         1.78,
@@ -490,7 +490,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_buy_5 = BuyLimitOrder(trader_inst)
-        limit_buy_5.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy_5.new(TraderOrderType.BUY_LIMIT,
                         "BTC/USD",
                         0.2122427,
                         3.72448,
@@ -498,7 +498,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_buy_6 = BuyLimitOrder(trader_inst)
-        limit_buy_6.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy_6.new(TraderOrderType.BUY_LIMIT,
                         "BTC/USD",
                         430,
                         1.05,
@@ -506,7 +506,7 @@ class TestPortfolio:
 
         # Test sell order
         limit_sell_2 = SellLimitOrder(trader_inst)
-        limit_sell_2.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell_2.new(TraderOrderType.SELL_LIMIT,
                          "BTC/USD",
                          10,
                          2,
@@ -514,7 +514,7 @@ class TestPortfolio:
 
         # Test stop loss order
         stop_loss_2 = StopLossOrder(trader_inst)
-        stop_loss_2.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.STOP_LOSS],
+        stop_loss_2.new(TraderOrderType.STOP_LOSS,
                         "BTC/USD",
                         10,
                         2,
@@ -522,7 +522,7 @@ class TestPortfolio:
 
         # Test sell order
         limit_sell_3 = SellLimitOrder(trader_inst)
-        limit_sell_3.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell_3.new(TraderOrderType.SELL_LIMIT,
                          "BTC/USD",
                          20,
                          1,
@@ -530,7 +530,7 @@ class TestPortfolio:
 
         # Test stop loss order
         stop_loss_3 = StopLossOrder(trader_inst)
-        stop_loss_3.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.STOP_LOSS],
+        stop_loss_3.new(TraderOrderType.STOP_LOSS,
                         "BTC/USD",
                         20,
                         1,
@@ -538,7 +538,7 @@ class TestPortfolio:
 
         # Test sell order
         limit_sell_4 = SellLimitOrder(trader_inst)
-        limit_sell_4.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell_4.new(TraderOrderType.SELL_LIMIT,
                          "BTC/USD",
                          50,
                          0.2,
@@ -546,7 +546,7 @@ class TestPortfolio:
 
         # Test stop loss order
         stop_loss_4 = StopLossOrder(trader_inst)
-        stop_loss_4.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.STOP_LOSS],
+        stop_loss_4.new(TraderOrderType.STOP_LOSS,
                         "BTC/USD",
                         45,
                         0.2,
@@ -554,7 +554,7 @@ class TestPortfolio:
 
         # Test sell order
         limit_sell_5 = SellLimitOrder(trader_inst)
-        limit_sell_5.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell_5.new(TraderOrderType.SELL_LIMIT,
                          "BTC/USD",
                          11,
                          0.7,
@@ -562,7 +562,7 @@ class TestPortfolio:
 
         # Test stop loss order
         stop_loss_5 = StopLossOrder(trader_inst)
-        stop_loss_5.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.STOP_LOSS],
+        stop_loss_5.new(TraderOrderType.STOP_LOSS,
                         "BTC/USD",
                         9,
                         0.7,
@@ -629,7 +629,7 @@ class TestPortfolio:
 
         # Test buy order
         market_buy = BuyMarketOrder(trader_inst)
-        market_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_MARKET],
+        market_buy.new(TraderOrderType.BUY_MARKET,
                        "ETH/USD",
                        7,
                        100,
@@ -652,7 +652,7 @@ class TestPortfolio:
 
         # Test buy order
         market_buy = BuyMarketOrder(trader_inst)
-        market_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_MARKET],
+        market_buy.new(TraderOrderType.BUY_MARKET,
                        "LTC/BTC",
                        0.0135222,
                        100,
@@ -675,7 +675,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_buy = BuyLimitOrder(trader_inst)
-        limit_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy.new(TraderOrderType.BUY_LIMIT,
                       "XRP/BTC",
                       0.00012232132312312,
                       3000.1214545,
@@ -700,7 +700,7 @@ class TestPortfolio:
 
         # Test buy order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "BTC/USD",
                        90,
                        4,
@@ -716,7 +716,7 @@ class TestPortfolio:
 
         # Test sell order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "BTC/USD",
                        90,
                        4,
@@ -725,7 +725,7 @@ class TestPortfolio:
         portfolio_inst.update_portfolio_available(limit_sell, True)
         # Test buy order
         limit_buy = BuyLimitOrder(trader_inst)
-        limit_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy.new(TraderOrderType.BUY_LIMIT,
                       "VEN/BTC",
                       0.5,
                       4,
@@ -735,7 +735,7 @@ class TestPortfolio:
 
         # Test buy order
         btc_limit_buy = BuyLimitOrder(trader_inst)
-        btc_limit_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        btc_limit_buy.new(TraderOrderType.BUY_LIMIT,
                           "BTC/USD",
                           10,
                           50,
@@ -745,7 +745,7 @@ class TestPortfolio:
 
         # Test buy order
         btc_limit_buy2 = BuyLimitOrder(trader_inst)
-        btc_limit_buy2.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        btc_limit_buy2.new(TraderOrderType.BUY_LIMIT,
                            "BTC/USD",
                            10,
                            50,

--- a/tests/unit_tests/trading_tests/test_previous_trading_state_manager.py
+++ b/tests/unit_tests/trading_tests/test_previous_trading_state_manager.py
@@ -1,0 +1,48 @@
+#  Drakkar-Software OctoBot
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+
+
+import ccxt
+import pytest
+
+from trading.exchanges.exchange_manager import ExchangeManager
+from tests.test_utils.config import load_test_config
+from trading.trader.previous_trading_state_manager import PreviousTradingStateManager
+from tests.test_utils.config import TEST_CONFIG_FOLDER
+
+
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio
+
+TESTS_STATE_SAVE_FOLDER = f"{TEST_CONFIG_FOLDER}/trading_states_tests/"
+
+
+async def init_default():
+    config = load_test_config()
+    exchange_manager = ExchangeManager(config, ccxt.binance, is_simulated=True)
+    await exchange_manager.initialize()
+    exchange_inst = exchange_manager.get_exchange()
+    return config, exchange_inst
+
+
+async def test_load_ok_file_no_trades():
+    config, exchange_inst = await init_default()
+    state_manager = PreviousTradingStateManager({exchange_inst.get_name(): None}, False, config,
+                                                save_file=f"{TESTS_STATE_SAVE_FOLDER}ok_ref.json")
+    assert state_manager.get_previous_state(exchange_inst, "simulator_initial_portfolio") == {
+        "BTC": 10,
+        "USD": 1000
+    }

--- a/tests/unit_tests/trading_tests/test_sub_portfolio.py
+++ b/tests/unit_tests/trading_tests/test_sub_portfolio.py
@@ -21,7 +21,7 @@ from config import TraderOrderType
 from tests.test_utils.config import load_test_config
 from tests.test_utils.order_util import fill_market_order, fill_limit_or_stop_order
 from trading.exchanges.exchange_manager import ExchangeManager
-from trading.trader.order import BuyMarketOrder, OrderConstants, SellLimitOrder, BuyLimitOrder, SellMarketOrder
+from trading.trader.order import BuyMarketOrder, SellLimitOrder, BuyLimitOrder, SellMarketOrder
 from trading.trader.portfolio import Portfolio
 from trading.trader.sub_portfolio import SubPortfolio
 from trading.trader.trader_simulator import TraderSimulator
@@ -90,7 +90,7 @@ class TestSubPortfolio:
 
         # Test buy order
         market_buy = BuyMarketOrder(trader_inst)
-        market_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_MARKET],
+        market_buy.new(TraderOrderType.BUY_MARKET,
                        "BTC/USD",
                        70,
                        10,
@@ -124,7 +124,7 @@ class TestSubPortfolio:
 
         # Test sell order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "BTC/USD",
                        60,
                        8,
@@ -161,7 +161,7 @@ class TestSubPortfolio:
 
         # Test buy order
         limit_buy = BuyLimitOrder(trader_inst)
-        limit_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy.new(TraderOrderType.BUY_LIMIT,
                       "BTC/USD",
                       70,
                       10,
@@ -192,7 +192,7 @@ class TestSubPortfolio:
 
         # Test buy order
         market_sell = SellMarketOrder(trader_inst)
-        market_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_MARKET],
+        market_sell.new(TraderOrderType.SELL_MARKET,
                         "BTC/USD",
                         80,
                         8,
@@ -227,7 +227,7 @@ class TestSubPortfolio:
 
         # Test buy order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "BTC/USD",
                        90,
                        4,

--- a/tests/unit_tests/trading_tests/test_trade.py
+++ b/tests/unit_tests/trading_tests/test_trade.py
@@ -1,0 +1,145 @@
+#  Drakkar-Software OctoBot
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+
+
+import ccxt
+import pytest
+
+from trading.exchanges.exchange_manager import ExchangeManager
+from config import *
+from tests.test_utils.config import load_test_config
+from trading.trader.trader_simulator import TraderSimulator
+from trading.trader.trade import Trade
+from trading.trader.order import SellLimitOrder
+
+
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio
+
+
+async def init_default():
+    config = load_test_config()
+    exchange_manager = ExchangeManager(config, ccxt.binance, is_simulated=True)
+    await exchange_manager.initialize()
+    exchange_inst = exchange_manager.get_exchange()
+    trader_inst = TraderSimulator(config, exchange_inst, 1)
+    await trader_inst.portfolio.initialize()
+    trades_manager_inst = trader_inst.get_trades_manager()
+    await trades_manager_inst.initialize()
+    trader_inst.stop_order_manager()
+    return config, exchange_inst, trader_inst, trades_manager_inst
+
+
+async def test_as_dict():
+    _, exchange_inst, trader_inst, trades_manager_inst = await init_default()
+    symbol = "BTC/USD"
+    new_order = SellLimitOrder(trader_inst)
+    new_order.new(TraderOrderType.SELL_LIMIT, symbol, 90, 4, 90)
+    new_order.fee = {
+        FeePropertyColumns.COST.value: 100,
+        FeePropertyColumns.CURRENCY.value: "BTC"
+    }
+    new_order.filled_price = 898
+    new_order.total_cost = 10
+    new_order.order_id = 101
+    new_order.creation_time = 42
+    new_order.canceled_time = 1010
+    new_order.executed_time = 10101
+    new_trade = Trade(exchange_inst, new_order)
+    trade_dict = new_trade.as_dict()
+    trade_dict.pop('exchange')
+    assert trade_dict == {
+        'order': None,
+        'from_previous_execution': False,
+        'currency': 'BTC',
+        'market': 'USD',
+        'quantity': 4,
+        'price': 898,
+        'cost': 10,
+        'order_type': 'SELL_LIMIT',
+        'final_status': 'OPEN',
+        'fee': {
+            'cost': 100,
+            'currency': 'BTC'
+        },
+        'creation_time': 42,
+        'order_id': 101,
+        'side': 'SELL',
+        'canceled_time': 1010,
+        'filled_time': 10101,
+        'symbol': 'BTC/USD',
+        'simulated': True
+    }
+
+
+async def test_from_dict():
+    _, exchange_inst, trader_inst, trades_manager_inst = await init_default()
+
+    # ok case
+    trade_dict = {
+        'exchange': 'xyz',
+        'order': None,
+        'from_previous_execution': False,
+        'currency': 'BTC',
+        'market': 'USD',
+        'quantity': 4,
+        'price': 898,
+        'cost': 10,
+        'order_type': 'SELL_LIMIT',
+        'final_status': 'OPEN',
+        'fee': {
+            'cost': 100,
+            'currency': 'BTC'
+        },
+        'creation_time': 42,
+        'order_id': 101,
+        'side': 'SELL',
+        'canceled_time': 1010,
+        'filled_time': 10101,
+        'symbol': 'BTC/USD',
+        'simulated': True
+    }
+    new_trade = Trade.from_dict(exchange_inst, trade_dict)
+    assert new_trade.exchange == exchange_inst
+    assert new_trade.order is None
+    assert new_trade.from_previous_execution is True
+    assert new_trade.currency == 'BTC'
+    assert new_trade.market == 'USD'
+    assert new_trade.price == 898
+    assert new_trade.cost == 10
+    assert new_trade.order_type == TraderOrderType.SELL_LIMIT
+    assert new_trade.final_status == OrderStatus.OPEN
+    assert new_trade.fee == {
+        'cost': 100,
+        'currency': 'BTC'
+    }
+    assert new_trade.creation_time == 42
+    assert new_trade.order_id == 101
+    assert new_trade.side == TradeOrderSide.SELL
+    assert new_trade.canceled_time == 1010
+    assert new_trade.filled_time == 10101
+    assert new_trade.symbol == 'BTC/USD'
+    assert new_trade.simulated is True
+
+    # not ok cases
+    with pytest.raises(RuntimeError):
+        trade_dict.pop('exchange')
+        Trade.from_dict(exchange_inst, trade_dict)
+        trade_dict['exchange'] = None
+
+    with pytest.raises(RuntimeError):
+        trade_dict.pop('order_id')
+        Trade.from_dict(exchange_inst, trade_dict)

--- a/tests/unit_tests/trading_tests/test_trader.py
+++ b/tests/unit_tests/trading_tests/test_trader.py
@@ -83,7 +83,7 @@ class TestTrader:
 
         # Test buy order
         market_buy = BuyMarketOrder(trader_inst)
-        market_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_MARKET],
+        market_buy.new(TraderOrderType.BUY_MARKET,
                        self.DEFAULT_SYMBOL,
                        70,
                        10,
@@ -106,7 +106,7 @@ class TestTrader:
 
         # Test buy order
         market_buy = BuyMarketOrder(trader_inst)
-        market_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_MARKET],
+        market_buy.new(TraderOrderType.BUY_MARKET,
                        self.DEFAULT_SYMBOL,
                        70,
                        10,
@@ -114,7 +114,7 @@ class TestTrader:
 
         # Test sell order
         market_sell = SellMarketOrder(trader_inst)
-        market_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_MARKET],
+        market_sell.new(TraderOrderType.SELL_MARKET,
                         self.DEFAULT_SYMBOL,
                         70,
                         10,
@@ -122,7 +122,7 @@ class TestTrader:
 
         # Test buy order
         limit_buy = BuyLimitOrder(trader_inst)
-        limit_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy.new(TraderOrderType.BUY_LIMIT,
                       self.DEFAULT_SYMBOL,
                       70,
                       10,
@@ -154,7 +154,7 @@ class TestTrader:
 
         # Test buy order
         market_buy = BuyMarketOrder(trader_inst)
-        market_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_MARKET],
+        market_buy.new(TraderOrderType.BUY_MARKET,
                        "BTC/EUR",
                        70,
                        10,
@@ -162,7 +162,7 @@ class TestTrader:
 
         # Test buy order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "NANO/USDT",
                        70,
                        10,
@@ -170,7 +170,7 @@ class TestTrader:
 
         # Test sell order
         market_sell = SellMarketOrder(trader_inst)
-        market_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_MARKET],
+        market_sell.new(TraderOrderType.SELL_MARKET,
                         self.DEFAULT_SYMBOL,
                         70,
                         10,
@@ -178,7 +178,7 @@ class TestTrader:
 
         # Test buy order
         limit_buy = BuyLimitOrder(trader_inst)
-        limit_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy.new(TraderOrderType.BUY_LIMIT,
                       self.DEFAULT_SYMBOL,
                       70,
                       10,
@@ -214,7 +214,7 @@ class TestTrader:
 
         # Test buy order
         market_buy = BuyMarketOrder(trader_inst)
-        market_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_MARKET],
+        market_buy.new(TraderOrderType.BUY_MARKET,
                        "BTC/EUR",
                        70,
                        10,
@@ -222,7 +222,7 @@ class TestTrader:
 
         # Test buy order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "XRB/BTC",
                        70,
                        10,
@@ -230,7 +230,7 @@ class TestTrader:
 
         # Test sell order
         market_sell = SellMarketOrder(trader_inst)
-        market_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_MARKET],
+        market_sell.new(TraderOrderType.SELL_MARKET,
                         self.DEFAULT_SYMBOL,
                         70,
                         10,
@@ -238,7 +238,7 @@ class TestTrader:
 
         # Test buy order
         limit_buy = BuyLimitOrder(trader_inst)
-        limit_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_LIMIT],
+        limit_buy.new(TraderOrderType.BUY_LIMIT,
                       self.DEFAULT_SYMBOL,
                       70,
                       10,
@@ -295,7 +295,7 @@ class TestTrader:
 
         # Test buy order
         market_buy = BuyMarketOrder(trader_inst)
-        market_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_MARKET],
+        market_buy.new(TraderOrderType.BUY_MARKET,
                        "BTC/EUR",
                        70,
                        10,
@@ -303,7 +303,7 @@ class TestTrader:
 
         # Test buy order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "NANO/USDT",
                        70,
                        10,
@@ -311,7 +311,7 @@ class TestTrader:
 
         # Test stop loss order
         stop_loss = StopLossOrder(trader_inst)
-        stop_loss.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.STOP_LOSS],
+        stop_loss.new(TraderOrderType.STOP_LOSS,
                       "BTC/USD",
                       60,
                       10,
@@ -423,7 +423,7 @@ class TestTrader:
 
         # Test buy order
         market_buy = BuyMarketOrder(trader_inst)
-        market_buy.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.BUY_MARKET],
+        market_buy.new(TraderOrderType.BUY_MARKET,
                        "BTC/EUR",
                        70,
                        10,
@@ -431,7 +431,7 @@ class TestTrader:
 
         # Test buy order
         limit_sell = SellLimitOrder(trader_inst)
-        limit_sell.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT],
+        limit_sell.new(TraderOrderType.SELL_LIMIT,
                        "NANO/USDT",
                        70,
                        10,
@@ -439,7 +439,7 @@ class TestTrader:
 
         # Test stop loss order
         stop_loss = StopLossOrder(trader_inst)
-        stop_loss.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.STOP_LOSS],
+        stop_loss.new(TraderOrderType.STOP_LOSS,
                       "BTC/USD",
                       60,
                       10,

--- a/tests/unit_tests/trading_tests/test_trades_manager.py
+++ b/tests/unit_tests/trading_tests/test_trades_manager.py
@@ -22,7 +22,7 @@ from config import *
 from tests.test_utils.config import load_test_config
 from trading.trader.trader_simulator import TraderSimulator
 from trading.trader.trade import Trade
-from trading.trader.order import SellLimitOrder, OrderConstants
+from trading.trader.order import SellLimitOrder
 from trading.trader.trades_manager import TradesManager
 
 
@@ -121,7 +121,7 @@ class TestTradesManager:
         assert len(trades_manager_inst.get_trade_history()) == 0
         symbol = "BTC/USD"
         new_order = SellLimitOrder(trader_inst)
-        new_order.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT], symbol, 90, 4, 90)
+        new_order.new(TraderOrderType.SELL_LIMIT, symbol, 90, 4, 90)
         new_trade = Trade(exchange_inst, new_order)
 
         # add new trade
@@ -138,7 +138,7 @@ class TestTradesManager:
         assert trades_manager_inst.select_trade_history() == trades_manager_inst.get_trade_history()
 
         new_order2 = SellLimitOrder(trader_inst)
-        new_order2.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT], "BTC/EUR", 90, 4, 90)
+        new_order2.new(TraderOrderType.SELL_LIMIT, "BTC/EUR", 90, 4, 90)
         new_trade2 = Trade(exchange_inst, new_order2)
 
         trades_manager_inst.add_new_trade_in_history(new_trade2)
@@ -150,7 +150,7 @@ class TestTradesManager:
         self.stop(trader_inst)
         symbol = "BTC/USD"
         new_order = SellLimitOrder(trader_inst)
-        new_order.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT], symbol, 90, 4, 90)
+        new_order.new(TraderOrderType.SELL_LIMIT, symbol, 90, 4, 90)
         new_order.fee = {
             FeePropertyColumns.COST.value: 100,
             FeePropertyColumns.CURRENCY.value: "BTC"
@@ -161,7 +161,7 @@ class TestTradesManager:
         assert trades_manager_inst.get_total_paid_fees() == {"BTC": 100}
 
         new_order2 = SellLimitOrder(trader_inst)
-        new_order2.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT], symbol, 90, 4, 90)
+        new_order2.new(TraderOrderType.SELL_LIMIT, symbol, 90, 4, 90)
         new_order2.fee = {
             FeePropertyColumns.COST.value: 200,
             FeePropertyColumns.CURRENCY.value: "PLOP"
@@ -172,7 +172,7 @@ class TestTradesManager:
         assert trades_manager_inst.get_total_paid_fees() == {"BTC": 100, "PLOP": 200}
 
         new_order3 = SellLimitOrder(trader_inst)
-        new_order3.new(OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT], symbol, 90, 4, 90)
+        new_order3.new(TraderOrderType.SELL_LIMIT, symbol, 90, 4, 90)
         new_order3.fee = {
             FeePropertyColumns.COST.value: 0.01111,
             FeePropertyColumns.CURRENCY.value: "PLOP"

--- a/tools/config_manager.py
+++ b/tools/config_manager.py
@@ -263,6 +263,15 @@ class ConfigManager:
                     yield symbol
 
     @staticmethod
+    def get_all_currencies(config):
+        currencies = set()
+        for symbol in ConfigManager.get_symbols(config):
+            quote, base = split_symbol(symbol)
+            currencies.add(quote)
+            currencies.add(base)
+        return currencies
+
+    @staticmethod
     def get_pairs(config, currency) -> []:
         pairs = []
         for symbol in ConfigManager.get_symbols(config):

--- a/tools/pretty_printer.py
+++ b/tools/pretty_printer.py
@@ -15,7 +15,6 @@
 #  License along with this library.
 
 from config import DICT_BULLET_TOKEN_STR
-from trading.trader.order import OrderConstants
 from trading.trader.portfolio import Portfolio
 from tools.timestamp_util import convert_timestamp_to_datetime
 from tools.number_util import round_into_str_with_max_digits
@@ -30,14 +29,8 @@ class PrettyPrinter:
     def open_order_pretty_printer(order, markdown=False):
         _, _, c = PrettyPrinter.get_markets(markdown)
         currency, market = order.get_currency_and_market()
+        order_type_name = order.get_order_type().name
 
-        try:
-            order_type_name = order.get_order_type().name
-        except AttributeError:
-            try:
-                order_type_name = OrderConstants.TraderOrderTypeClasses[order.get_order_type()].__name__
-            except KeyError:
-                order_type_name = order.get_order_type().__class__.__name__
         return f"{c}{order_type_name}{c}: {c}{PrettyPrinter.get_min_string_from_number(order.get_origin_quantity())} " \
             f"{currency}{c} at {c}{PrettyPrinter.get_min_string_from_number(order.get_origin_price())} {market}{c} " \
             f" {order.get_exchange().get_name()} " \
@@ -48,14 +41,8 @@ class PrettyPrinter:
         _, _, c = PrettyPrinter.get_markets(markdown)
         currency = trade.currency
         market = trade.market
-
-        try:
-            order_type_name = trade.order_type.name
-        except AttributeError:
-            try:
-                order_type_name = OrderConstants.TraderOrderTypeClasses[trade.order_type].__name__
-            except KeyError:
-                order_type_name = trade.order_type.__class__.__name__
+        order_type_name = trade.order_type.name
+        
         return f"{c}{order_type_name}{c}: {c}{PrettyPrinter.get_min_string_from_number(trade.quantity)} {currency}{c}" \
             f" at {c}{PrettyPrinter.get_min_string_from_number(trade.price)} {market}{c} " \
             f"{trade.exchange.get_name()} " \

--- a/trading/exchanges/abstract_exchange.py
+++ b/trading/exchanges/abstract_exchange.py
@@ -26,7 +26,7 @@ class AbstractExchange:
         self.config = config
         self.exchange_type = exchange_type
         self.name = self.exchange_type.__name__
-        self.logger = get_logger(f"{self.__class__.__name__} - {self.name}")
+        self.logger = get_logger(f"{self.__class__.__name__}[{self.name}]")
         self.trader = None
 
         self.exchange_manager = None

--- a/trading/exchanges/exchange_simulator/exchange_simulator.py
+++ b/trading/exchanges/exchange_simulator/exchange_simulator.py
@@ -17,7 +17,8 @@
 import copy
 import time
 
-from backtesting.backtesting import Backtesting, BacktestingEndedException
+from backtesting import BacktestingEndedException, backtesting_enabled
+from backtesting.backtesting import Backtesting
 from backtesting.collector.data_file_manager import interpret_file_name
 from backtesting.collector.data_parser import DataCollectorParser
 from config import TimeFrames, ExchangeConstantsMarketStatusColumns, CONFIG_BACKTESTING, \
@@ -191,7 +192,7 @@ class ExchangeSimulator(AbstractExchange):
 
         max_price = tf[PriceIndexes.IND_PRICE_HIGH.value]
         min_price = tf[PriceIndexes.IND_PRICE_LOW.value]
-        timestamp = tf[PriceIndexes.IND_PRICE_TIME.value] if Backtesting.enabled(self.config) else time.time()
+        timestamp = tf[PriceIndexes.IND_PRICE_TIME.value] if backtesting_enabled(self.config) else time.time()
 
         # TODO generate trades with different patterns (linear, waves, random, etc)
         for _ in range(0, self.RECENT_TRADES_TO_CREATE - 2):
@@ -300,7 +301,7 @@ class ExchangeSimulator(AbstractExchange):
                 [PriceIndexes.IND_PRICE_TIME.value]
         else:
             self.logger.error(f"No data for the timeframes: {time_frames} in loaded backtesting file.")
-            if Backtesting.enabled(self.config):
+            if backtesting_enabled(self.config):
                 self.backtesting.end(symbol)
 
     """

--- a/trading/exchanges/exchange_simulator/exchange_simulator.py
+++ b/trading/exchanges/exchange_simulator/exchange_simulator.py
@@ -31,7 +31,6 @@ from tools.symbol_util import split_symbol
 from tools.data_util import DataUtil
 from tools.number_util import round_into_str_with_max_digits
 from trading import AbstractExchange
-from trading.trader.order import OrderConstants
 from trading.exchanges.exchange_symbol_data import SymbolData
 
 
@@ -487,8 +486,7 @@ class ExchangeSimulator(AbstractExchange):
             [ExchangeConstantsMarketStatusColumns.PRECISION_PRICE.value]
         cost = float(round_into_str_with_max_digits(quantity * rate, precision))
 
-        if order_type == OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_MARKET] \
-                or order_type == OrderConstants.TraderOrderTypeClasses[TraderOrderType.SELL_LIMIT]:
+        if order_type == TraderOrderType.SELL_MARKET or order_type == TraderOrderType.SELL_LIMIT:
             cost = float(round_into_str_with_max_digits(cost * price, precision))
             fee_currency = market
 

--- a/trading/trader/order.py
+++ b/trading/trader/order.py
@@ -54,7 +54,7 @@ class Order:
     market: str = None
     order_id: str = None
     status: OrderStatus = OrderStatus.OPEN
-    order_type: Any = None
+    order_type: TraderOrderType = None
     timestamp: int = None
     creation_time: int = time.time()
     canceled_time: int = 0
@@ -244,16 +244,16 @@ class Order:
 
     def get_string_info(self):
         return (f"{self.get_order_symbol()} | "
-                f"{self.get_order_type()} | "
+                f"{self.get_order_type().name} | "
                 f"Price : {self.get_origin_price()} | "
                 f"Quantity : {self.get_origin_quantity()} | "
                 f"Status : {self.get_status()}")
 
     def infer_taker_or_maker(self):
         if self.taker_or_maker is None:
-            if self.order_type == SellMarketOrder \
-                    or self.order_type == BuyMarketOrder \
-                    or self.order_type == StopLossOrder:
+            if self.order_type == TraderOrderType.SELL_MARKET \
+                    or self.order_type == TraderOrderType.BUY_MARKET \
+                    or self.order_type == TraderOrderType.STOP_LOSS:
                 # always true
                 return ExchangeConstantsMarketPropertyColumns.TAKER.value
             else:

--- a/trading/trader/order.py
+++ b/trading/trader/order.py
@@ -93,6 +93,8 @@ class Order:
             linked_to=None,
             linked_portfolio=None):
 
+        if not isinstance(order_type, TraderOrderType):
+            get_logger(self.get_name()).error(f"order initialized with an invalid order-type: {order_type}")
         self.order_id = order_id
         self.origin_price = price
         self.status = status

--- a/trading/trader/orders_manager.py
+++ b/trading/trader/orders_manager.py
@@ -40,7 +40,8 @@ class OrdersManager:
         self.trader = trader
         self.order_list = []
         self.last_symbol_prices = {}
-        self.logger = get_logger(f"{self.__class__.__name__}{'Simulator' if self.trader.simulate else ''}")
+        self.logger = get_logger(f"{self.__class__.__name__}{'Simulator' if self.trader.simulate else ''}"
+                                 f"[{self.trader.exchange.get_name()}]")
 
         if self.trader.get_exchange().is_web_socket_available():
             self.order_refresh_time = ORDER_REFRESHER_TIME_WS
@@ -50,10 +51,11 @@ class OrdersManager:
     def add_order_to_list(self, order):
         if self.should_add_order(order):
             self.order_list.append(order)
-            self.logger.debug(f"Order added to open orders (currently {len(self.order_list)} open order(s))")
+            self.logger.debug(f"Order added to open orders (total: {len(self.order_list)} open order"
+                              f"{'s' if len(self.order_list) > 1 else ''})")
         else:
             self.logger.debug(f"Order not added to open orders (already in open order: {self._order_in_list(order)}) "
-                              f"(currently {len(self.order_list)} open order(s))")
+                              f"(total: {len(self.order_list)} open order{'s' if len(self.order_list) > 1 else ''})")
 
     def should_add_order(self, order):
         return not self._order_in_list(order) and \

--- a/trading/trader/orders_manager.py
+++ b/trading/trader/orders_manager.py
@@ -19,7 +19,7 @@ from concurrent.futures import CancelledError
 import copy
 from ccxt.async_support import BaseError, InsufficientFunds
 
-from backtesting.backtesting import Backtesting
+from backtesting import backtesting_enabled
 from config import ORDER_REFRESHER_TIME, OrderStatus, ORDER_REFRESHER_TIME_WS, ExchangeConstantsTickersColumns as eC
 from tools.logging.logging_util import get_logger
 from trading.trader.order import Order, StopLossLimitOrder, StopLossOrder
@@ -127,7 +127,7 @@ class OrdersManager:
 
         exchange = self.trader.get_exchange()
 
-        if Backtesting.enabled(self.config):
+        if backtesting_enabled(self.config):
             last_symbol_price = await self.trader.get_exchange().get_recent_trades(symbol)
 
         # Exchange call when not backtesting

--- a/trading/trader/portfolio.py
+++ b/trading/trader/portfolio.py
@@ -17,9 +17,11 @@
 from tools.logging.logging_util import get_logger
 from asyncio import Lock
 
-from config import *
+from config import CONFIG_SIMULATOR, CONFIG_STARTING_PORTFOLIO, CONFIG_PORTFOLIO_FREE, CONFIG_PORTFOLIO_TOTAL, \
+    TradeOrderSide, TraderOrderType, SIMULATOR_CURRENT_PORTFOLIO
 from trading.trader.order import OrderConstants
 from tools.initializable import Initializable
+from backtesting import backtesting_enabled
 
 """ The Portfolio class manage an exchange portfolio
 This will begin by loading current exchange portfolio (by pulling user data)
@@ -60,8 +62,30 @@ class Portfolio(Initializable):
                 await self.update_portfolio_balance()
 
     def set_starting_simulated_portfolio(self):
-        self.portfolio = {currency: {Portfolio.AVAILABLE: total, Portfolio.TOTAL: total}
-                          for currency, total in self.config[CONFIG_SIMULATOR][CONFIG_STARTING_PORTFOLIO].items()}
+        if self.trader.get_loaded_previous_state():
+            # load portfolio from previous execution
+            portfolio_amount_dict = self.trader.get_previous_state_manager().get_previous_state(
+                self.trader.get_exchange(),
+                SIMULATOR_CURRENT_PORTFOLIO
+            )
+        else:
+            # load new portfolio from config settings
+            portfolio_amount_dict = self.config[CONFIG_SIMULATOR][CONFIG_STARTING_PORTFOLIO]
+        try:
+            self.portfolio = self.get_portfolio_from_amount_dict(portfolio_amount_dict)
+        except Exception as e:
+            self.logger.warning(f"Error when loading trading history, will reset history. ({e})")
+            self.logger.exception(e)
+            self.trader.get_previous_state_manager.reset_trading_history()
+            self.portfolio = self.get_portfolio_from_amount_dict(
+                self.config[CONFIG_SIMULATOR][CONFIG_STARTING_PORTFOLIO])
+
+    @staticmethod
+    def get_portfolio_from_amount_dict(amount_dict):
+        if not all(isinstance(i, (int, float)) for i in amount_dict.values()):
+            raise RuntimeError("Portfolio has to be initialized using numbers")
+        return {currency: {Portfolio.AVAILABLE: total, Portfolio.TOTAL: total}
+                for currency, total in amount_dict.items()}
 
     async def update_portfolio_balance(self):
         if not self.is_simulated and self.is_enabled:
@@ -135,6 +159,14 @@ class Portfolio(Initializable):
 
             self.logger.info(f"Portfolio updated | {currency} {currency_portfolio_num} | {market} "
                              f"{market_portfolio_num} | Current Portfolio : {self.portfolio}")
+
+            if not backtesting_enabled(self.config) and self.trader.get_previous_state_manager() is not None:
+                if self.is_simulated:
+                    self.trader.get_previous_state_manager().update_previous_states(self.trader.exchange,
+                                                                                    simulated_portfolio=self.portfolio)
+                else:
+                    self.trader.get_previous_state_manager().update_previous_states(self.trader.exchange,
+                                                                                    real_portfolio=self.portfolio)
         else:
             await self.update_portfolio_balance()
             self.logger.info(f"Portfolio updated | Current Portfolio : {self.portfolio}")

--- a/trading/trader/previous_trading_state_manager.py
+++ b/trading/trader/previous_trading_state_manager.py
@@ -30,8 +30,9 @@ class PreviousTradingStateManager:
 
     ERROR_MESSAGE = "Impossible to start from the previous trading state: "
 
-    def __init__(self, target_exchanges, reset_simulator, config):
+    def __init__(self, target_exchanges, reset_simulator, config, save_file=SIMULATOR_STATE_SAVE_FILE):
         self.logger = get_logger(self.__class__.__name__)
+        self.save_file = save_file
         if reset_simulator:
             self.reset_trading_history()
         self.reset_state_history = False
@@ -46,8 +47,8 @@ class PreviousTradingStateManager:
         return self.first_data
 
     def reset_trading_history(self):
-        if path.isfile(SIMULATOR_STATE_SAVE_FILE):
-            remove(SIMULATOR_STATE_SAVE_FILE)
+        if path.isfile(self.save_file):
+            remove(self.save_file)
         self.reset_state_history = True
 
     def update_previous_states(self, exchange, simulated_portfolio=None, trade=None, simulated_initial_portfolio=None,
@@ -95,7 +96,7 @@ class PreviousTradingStateManager:
         return self._previous_state[exchange.get_name()][element]
 
     def _save_state_file(self):
-        with open(SIMULATOR_STATE_SAVE_FILE, 'w') as state_file:
+        with open(self.save_file, 'w') as state_file:
             json.dump(self._previous_state, state_file, indent=True)
 
     @staticmethod
@@ -117,9 +118,9 @@ class PreviousTradingStateManager:
         }
 
     def _load_previous_state(self, target_exchanges, config):
-        if path.isfile(SIMULATOR_STATE_SAVE_FILE):
+        if path.isfile(self.save_file):
             try:
-                potential_previous_state = load_config(SIMULATOR_STATE_SAVE_FILE)
+                potential_previous_state = load_config(self.save_file)
                 if isinstance(potential_previous_state, dict):
                     required_values = [SIMULATOR_INITIAL_STARTUP_PORTFOLIO, REAL_INITIAL_STARTUP_PORTFOLIO,
                                        SIMULATOR_CURRENT_PORTFOLIO, SIMULATOR_TRADE_HISTORY, REAL_TRADE_HISTORY,

--- a/trading/trader/previous_trading_state_manager.py
+++ b/trading/trader/previous_trading_state_manager.py
@@ -1,0 +1,163 @@
+#  Drakkar-Software OctoBot
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+
+from os import path, remove
+import json
+
+from config import SIMULATOR_STATE_SAVE_FILE, SIMULATOR_INITIAL_STARTUP_PORTFOLIO, SIMULATOR_CURRENT_PORTFOLIO, \
+    SIMULATOR_TRADE_HISTORY, SIMULATOR_INITIAL_STARTUP_PORTFOLIO_VALUE, WATCHED_MARKETS_INITIAL_STARTUP_VALUES, \
+    SIMULATOR_REFERENCE_MARKET, REAL_INITIAL_STARTUP_PORTFOLIO, REAL_TRADE_HISTORY, REAL_INITIAL_STARTUP_PORTFOLIO_VALUE
+from config.config import load_config
+from tools.config_manager import ConfigManager
+from tools.logging.logging_util import get_logger
+from trading.trader.portfolio import Portfolio
+
+
+class PreviousTradingStateManager:
+
+    ERROR_MESSAGE = "Impossible to start from the previous trading state: "
+
+    def __init__(self, target_exchanges, reset_simulator, config):
+        self.logger = get_logger(self.__class__.__name__)
+        if reset_simulator:
+            self.reset_trading_history()
+        self.reset_state_history = False
+        self._previous_state = {}
+        if not self._load_previous_state(target_exchanges, config):
+            self._previous_state = self._initialize_new_previous_state(target_exchanges)
+            self.first_data = True
+        else:
+            self.first_data = False
+
+    def should_initialize_data(self):
+        return self.first_data
+
+    def reset_trading_history(self):
+        if path.isfile(SIMULATOR_STATE_SAVE_FILE):
+            remove(SIMULATOR_STATE_SAVE_FILE)
+        self.reset_state_history = True
+
+    def update_previous_states(self, exchange, simulated_portfolio=None, trade=None, simulated_initial_portfolio=None,
+                               real_initial_portfolio=None, simulated_initial_portfolio_value=None,
+                               real_initial_portfolio_value=None, watched_markets_initial_values=None,
+                               reference_market=None):
+        if not self.reset_state_history:
+            try:
+                exchange_name = exchange.get_name()
+                if simulated_portfolio is not None:
+                    self._previous_state[exchange_name][SIMULATOR_CURRENT_PORTFOLIO] = \
+                        {currency: value[Portfolio.TOTAL] for currency, value in simulated_portfolio.items()}
+                if trade is not None:
+                    trade_dict = trade.as_dict()
+                    trade_key = REAL_TRADE_HISTORY
+                    if trade.simulated:
+                        trade_key = SIMULATOR_TRADE_HISTORY
+                    self._previous_state[exchange_name][trade_key].append(trade_dict)
+                if simulated_initial_portfolio is not None:
+                    self._previous_state[exchange_name][SIMULATOR_INITIAL_STARTUP_PORTFOLIO] =  \
+                        {currency: value[Portfolio.TOTAL] for currency, value in simulated_initial_portfolio.items()}
+                if real_initial_portfolio is not None:
+                    self._previous_state[exchange_name][REAL_INITIAL_STARTUP_PORTFOLIO] =  \
+                        {currency: value[Portfolio.TOTAL] for currency, value in real_initial_portfolio.items()}
+                if simulated_initial_portfolio_value is not None:
+                    self._previous_state[exchange_name][SIMULATOR_INITIAL_STARTUP_PORTFOLIO_VALUE] = \
+                        simulated_initial_portfolio_value
+                if real_initial_portfolio_value is not None:
+                    self._previous_state[exchange_name][REAL_INITIAL_STARTUP_PORTFOLIO_VALUE] = \
+                        real_initial_portfolio_value
+                if watched_markets_initial_values is not None:
+                    self._previous_state[exchange_name][WATCHED_MARKETS_INITIAL_STARTUP_VALUES] = \
+                        watched_markets_initial_values
+                if reference_market is not None:
+                    self._previous_state[exchange_name][SIMULATOR_REFERENCE_MARKET] = reference_market
+                self._save_state_file()
+            except Exception as e:
+                self.logger.error(f"Error when saving simulator state: {e}")
+                self.logger.exception(e)
+
+    def has_previous_state(self, exchange):
+        return exchange.get_name() in self._previous_state
+
+    def get_previous_state(self, exchange, element):
+        return self._previous_state[exchange.get_name()][element]
+
+    def _save_state_file(self):
+        with open(SIMULATOR_STATE_SAVE_FILE, 'w') as state_file:
+            json.dump(self._previous_state, state_file, indent=True)
+
+    @staticmethod
+    def _initialize_new_previous_state(target_exchanges):
+        return {exchange: PreviousTradingStateManager._get_previous_state_model() for exchange in target_exchanges}
+
+    @staticmethod
+    def _get_previous_state_model():
+        return {
+            SIMULATOR_INITIAL_STARTUP_PORTFOLIO: None,
+            REAL_INITIAL_STARTUP_PORTFOLIO: None,
+            SIMULATOR_CURRENT_PORTFOLIO: None,
+            SIMULATOR_TRADE_HISTORY: [],
+            REAL_TRADE_HISTORY: [],
+            SIMULATOR_INITIAL_STARTUP_PORTFOLIO_VALUE: None,
+            REAL_INITIAL_STARTUP_PORTFOLIO_VALUE: None,
+            WATCHED_MARKETS_INITIAL_STARTUP_VALUES: None,
+            SIMULATOR_REFERENCE_MARKET: None
+        }
+
+    def _load_previous_state(self, target_exchanges, config):
+        if path.isfile(SIMULATOR_STATE_SAVE_FILE):
+            try:
+                potential_previous_state = load_config(SIMULATOR_STATE_SAVE_FILE)
+                if isinstance(potential_previous_state, dict):
+                    required_values = [SIMULATOR_INITIAL_STARTUP_PORTFOLIO, REAL_INITIAL_STARTUP_PORTFOLIO,
+                                       SIMULATOR_CURRENT_PORTFOLIO, SIMULATOR_TRADE_HISTORY, REAL_TRADE_HISTORY,
+                                       SIMULATOR_INITIAL_STARTUP_PORTFOLIO_VALUE, REAL_INITIAL_STARTUP_PORTFOLIO_VALUE,
+                                       WATCHED_MARKETS_INITIAL_STARTUP_VALUES, SIMULATOR_REFERENCE_MARKET]
+                    # check trading data
+                    for exchange, state_data in potential_previous_state.items():
+                        if all(v in state_data for v in required_values):
+                            self._previous_state[exchange] = potential_previous_state[exchange]
+                        else:
+                            self.logger.warning(f"{self.ERROR_MESSAGE}Missing data in saving file.")
+                            return False
+                    # check symbol data
+                    found_currencies_prices = {currency: False for currency in ConfigManager.get_all_currencies(config)}
+                    for exchange_data in self._previous_state.values():
+                        missing_traded_currencies = set()
+                        for currency in exchange_data[WATCHED_MARKETS_INITIAL_STARTUP_VALUES].keys():
+                            if currency in found_currencies_prices:
+                                found_currencies_prices[currency] = True
+                            else:
+                                missing_traded_currencies.add(currency)
+                        if missing_traded_currencies:
+                            self.logger.warning(f"{self.ERROR_MESSAGE}Missing trading pair(s) for "
+                                                f"{', '.join(missing_traded_currencies)}.")
+                            return False
+                    if not all(found_currencies_prices.values()):
+                        missing_symbol = [c for c, v in found_currencies_prices.items() if not v]
+                        self.logger.warning(f"{self.ERROR_MESSAGE}Missing symbol historical "
+                                            f"data for {', '.join(missing_symbol)}.")
+                        return False
+                if not all(e in self._previous_state for e in target_exchanges):
+                    missing_exchanges = [e for e in target_exchanges if e not in self._previous_state]
+                    self.logger.warning(f"{self.ERROR_MESSAGE}Missing historical data from exchange(s): "
+                                        f"{', '.join(missing_exchanges)}.")
+                    return False
+            except Exception as e:
+                self.logger.warning(f"{self.ERROR_MESSAGE}{e}")
+                return False
+            return True
+        else:
+            return False

--- a/trading/trader/trade.py
+++ b/trading/trader/trade.py
@@ -38,7 +38,7 @@ class Trade:
     order: Any
     from_previous_execution: bool = field(init=True, repr=False, default=False)
     order_id: str = field(init=False, repr=False)
-    order_type: Any = field(init=False, repr=False)
+    order_type: TraderOrderType = field(init=False, repr=False)
     price: float = field(init=False, repr=False)
     cost: float = field(init=False, repr=False)
     quantity: float = field(init=False, repr=False)

--- a/trading/trader/trader.py
+++ b/trading/trader/trader.py
@@ -45,7 +45,7 @@ class Trader(Initializable):
 
         # logging
         self.trader_type_str = REAL_TRADER_STR
-        self.logger = get_logger(self.__class__.__name__)
+        self.logger = get_logger(f"{self.__class__.__name__}[{self.exchange.get_name()}]")
 
         if not hasattr(self, 'simulate'):
             self.simulate = False

--- a/trading/trader/trader_simulator.py
+++ b/trading/trader/trader_simulator.py
@@ -14,7 +14,7 @@
 #  You should have received a copy of the GNU Lesser General Public
 #  License along with this library.
 
-from config import CONFIG_ENABLED_OPTION, CONFIG_SIMULATOR, SIMULATOR_TRADER_STR
+from config import CONFIG_ENABLED_OPTION, CONFIG_SIMULATOR, SIMULATOR_TRADER_STR, SIMULATOR_TRADE_HISTORY
 from trading.trader.trader import Trader
 
 """ TraderSimulator has a role of exchange response simulator
@@ -22,9 +22,14 @@ from trading.trader.trader import Trader
 
 
 class TraderSimulator(Trader):
-    def __init__(self, config, exchange, order_refresh_time=None):
+
+    TRADE_HISTORY_KEY = SIMULATOR_TRADE_HISTORY
+    NO_HISTORY_MESSAGE = "Starting a fresh new trading simulation session using trader simulator initial portfolio " \
+                         "in configuration."
+
+    def __init__(self, config, exchange, order_refresh_time=None, previous_state_manager=None):
         self.simulate = True
-        super().__init__(config, exchange, order_refresh_time)
+        super().__init__(config, exchange, order_refresh_time, previous_state_manager)
 
         self.trader_type_str = SIMULATOR_TRADER_STR
 

--- a/trading/trader/trades_manager.py
+++ b/trading/trader/trades_manager.py
@@ -19,11 +19,14 @@ from copy import deepcopy
 from tools.logging.logging_util import get_logger
 
 from config import CONFIG_TRADING, CONFIG_TRADER_REFERENCE_MARKET, DEFAULT_REFERENCE_MARKET, \
-    CONFIG_CRYPTO_CURRENCIES, CONFIG_CRYPTO_PAIRS, FeePropertyColumns
-from trading.trader.portfolio import Portfolio, ExchangeConstantsTickersColumns
+    CONFIG_CRYPTO_CURRENCIES, CONFIG_CRYPTO_PAIRS, FeePropertyColumns, ExchangeConstantsTickersColumns, \
+    WATCHED_MARKETS_INITIAL_STARTUP_VALUES, SIMULATOR_INITIAL_STARTUP_PORTFOLIO, REAL_INITIAL_STARTUP_PORTFOLIO, \
+    SIMULATOR_INITIAL_STARTUP_PORTFOLIO_VALUE, REAL_INITIAL_STARTUP_PORTFOLIO_VALUE
+from trading.trader.portfolio import Portfolio
 from tools.symbol_util import merge_currencies, split_symbol
 from trading.exchanges.exchange_simulator.exchange_simulator import ExchangeSimulator
 from tools.initializable import Initializable
+from backtesting import backtesting_enabled
 
 """ TradesManager will store all trades performed by the exchange trader
 Another feature of TradesManager is the profitability calculation
@@ -108,6 +111,10 @@ class TradesManager(Initializable):
     def add_new_trade_in_history(self, trade):
         if trade not in self.trade_history:
             self.trade_history.append(trade)
+
+        if not (backtesting_enabled(self.config) or trade.from_previous_execution or
+                self.trader.get_previous_state_manager() is None):
+            self.trader.get_previous_state_manager().update_previous_states(self.exchange, trade=trade)
 
     """ get currencies prices update currencies data by polling tickers from exchange
     and set currencies_prices attribute
@@ -210,14 +217,54 @@ class TradesManager(Initializable):
 
         self.portfolio_current_value = await self._update_portfolio_current_value(current_portfolio)
 
-    async def _init_origin_portfolio_and_currencies_value(self):
-        self.origin_crypto_currencies_values = await self._evaluate_config_crypto_currencies_values()
-        async with self.portfolio.get_lock():
-            self.origin_portfolio = deepcopy(self.portfolio.get_portfolio())
+    async def _init_origin_portfolio_and_currencies_value(self, force_ignore_history=False):
+        previous_state_manager = self.trader.get_previous_state_manager()
+        if backtesting_enabled(self.config) or force_ignore_history or \
+                previous_state_manager is None or previous_state_manager.should_initialize_data():
+            self.origin_crypto_currencies_values = await self._evaluate_config_crypto_currencies_values()
+            async with self.portfolio.get_lock():
+                self.origin_portfolio = deepcopy(self.portfolio.get_portfolio())
 
-        self.portfolio_origin_value = \
-            await self._update_portfolio_current_value(self.origin_portfolio,
-                                                       currencies_values=self.origin_crypto_currencies_values)
+            self.portfolio_origin_value = \
+                await self._update_portfolio_current_value(self.origin_portfolio,
+                                                           currencies_values=self.origin_crypto_currencies_values)
+
+            if not backtesting_enabled(self.config) and previous_state_manager is not None:
+                if self.trader.simulate:
+                    previous_state_manager.update_previous_states(
+                        self.exchange,
+                        simulated_portfolio=deepcopy(self.origin_portfolio),
+                        simulated_initial_portfolio=deepcopy(self.origin_portfolio),
+                        simulated_initial_portfolio_value=self.portfolio_origin_value,
+                        watched_markets_initial_values=self.origin_crypto_currencies_values,
+                        reference_market=self.reference_market
+                    )
+                else:
+                    previous_state_manager.update_previous_states(
+                        self.exchange,
+                        real_initial_portfolio=deepcopy(self.origin_portfolio),
+                        real_initial_portfolio_value=self.portfolio_origin_value,
+                        watched_markets_initial_values=self.origin_crypto_currencies_values,
+                        reference_market=self.reference_market
+                    )
+        else:
+            try:
+                self.origin_crypto_currencies_values = \
+                    previous_state_manager.get_previous_state(self.exchange, WATCHED_MARKETS_INITIAL_STARTUP_VALUES)
+                portfolio_key = SIMULATOR_INITIAL_STARTUP_PORTFOLIO if self.trader.simulate \
+                    else REAL_INITIAL_STARTUP_PORTFOLIO
+                self.origin_portfolio = Portfolio.get_portfolio_from_amount_dict(
+                    previous_state_manager.get_previous_state(self.exchange, portfolio_key)
+                )
+                portfolio_origin_value_key = SIMULATOR_INITIAL_STARTUP_PORTFOLIO_VALUE if self.trader.simulate \
+                    else REAL_INITIAL_STARTUP_PORTFOLIO_VALUE
+                self.portfolio_origin_value = \
+                    previous_state_manager.get_previous_state(self.exchange, portfolio_origin_value_key)
+            except Exception as e:
+                self.logger.warning(f"Error when loading trading history, will reset history. ({e})")
+                self.logger.exception(e)
+                previous_state_manager.reset_trading_history()
+                await self._init_origin_portfolio_and_currencies_value(force_ignore_history=True)
 
     async def _get_origin_portfolio_current_value(self, refresh_values=False):
         if refresh_values:

--- a/trading/trader/trades_manager.py
+++ b/trading/trader/trades_manager.py
@@ -38,7 +38,7 @@ class TradesManager(Initializable):
         self.trader = trader
         self.portfolio = trader.get_portfolio()
         self.exchange = trader.get_exchange()
-        self.logger = get_logger(self.__class__.__name__)
+        self.logger = get_logger(f"{self.__class__.__name__}[{self.exchange.get_name()}]")
 
         self.trade_history = []
         self.profitability = 0


### PR DESCRIPTION
Are now kept between instances (if symbol config did not change):
* simulator & real traders trade history
* initial portfolio (for initial/no trade portfolio profitability & after trade profitability)
* watched symbols profitability 

bot started after: 03:34:24
![image](https://user-images.githubusercontent.com/9078616/54484408-6af7ce80-4866-11e9-8b70-d168c7b22496.png)

reset history from interface
![image](https://user-images.githubusercontent.com/9078616/54484414-97134f80-4866-11e9-807d-d95273e8f2c7.png)
