### PR TITLE
[Version] prepare 0.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OctoBot [0.3.2-beta](https://github.com/Drakkar-Software/OctoBot/tree/dev/docs/CHANGELOG.md)
+# OctoBot [0.3.3-beta](https://github.com/Drakkar-Software/OctoBot/tree/dev/docs/CHANGELOG.md)
 [![PyPI](https://img.shields.io/pypi/v/OctoBot.svg)](https://pypi.python.org/pypi/OctoBot/)
 [![Code Factor](https://www.codefactor.io/repository/github/Drakkar-Software/OctoBot/badge)](https://www.codefactor.io/repository/github/Drakkar-Software/OctoBot/overview/dev) 
 [![Downloads](https://pepy.tech/badge/octobot/month)](https://pepy.tech/project/octobot)

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -19,7 +19,7 @@ from enum import Enum
 from typing import NewType, Any, Dict
 
 PROJECT_NAME = "OctoBot"
-SHORT_VERSION = "0.3.2"  # major.minor.revision
+SHORT_VERSION = "0.3.3"  # major.minor.revision
 PATCH_VERSION = ""  # patch : pX
 VERSION_DEV_PHASE = ""  # alpha : a / beta : b / release candidate : rc
 VERSION_PHASE = ""  # XX
@@ -278,7 +278,7 @@ CONFIG_TENTACLES_KEY = "tentacles-packages"
 TENTACLE_PACKAGE_DESCRIPTION = "package_description"
 EVALUATOR_CONFIG_FOLDER = "config"
 TENTACLES_TRADING_MODE_PATH = "Mode"
-TENTACLES_DEFAULT_BRANCH = "dev"
+TENTACLES_DEFAULT_BRANCH = SHORT_VERSION
 TENTACLES_FORCE_CONFIRM_PARAM = "force"
 
 # Files

--- a/config/config_schema.json
+++ b/config/config_schema.json
@@ -44,6 +44,13 @@
                 "quote": {
                     "type": "string"
                     }
+                },
+                "add": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string"
+                    }
                 }
            }
         }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,37 @@
 *It is strongly advised to perform an update of your tentacles after updating OctoBot. (start.py -p install all)*
 
+Changelog for 0.3.3-beta
+====================
+*Released date : April 18 2019*
+
+# Concerned issues :
+    #425 [Telemetry] Create telemetry deamon
+    #731 [Trader] Allow to start from the previous execution last move
+    #734 [Order] order_type is not consistent
+    #740 [RunInAsyncMainLoop] problem with exchange commands
+    #741 [WebInterface] add possibility to cancel orders
+    #747 [Backtesting] prepare for multiple data formats
+    #749 [Backtesting] impossible to display candles on specific timeframe from web interface
+    #750 [OrderCreator] error when computing order price
+    #751 [Backtesting] problem when saving config from web interface on backtesting
+    #752 [WebInterface] candles display bug
+    #756 [OrderManager] call_order_update_callback not called when exception in _update_order_status
+    #785 [Metrics] community metrics display
+    #792 [Web interface][Configuration] force display of parameters that are not in config.json
+
+# New features :
+    - Cancel orders from web interface
+    - Community metrics though optionnal and anonymous telemetry
+    - Added bot trader state save and recovery
+    - Added telegram commands
+    
+
+# Bug fixes :
+    - Fixed several bugs related to traders
+    - Fixed an exchange timeout bug
+    - Fixed web interface bugs
+    - Fixed order creator bugs
+
 Changelog for 0.3.2-beta
 ====================
 *Released date : March 10 2019*


### PR DESCRIPTION
Changelog for 0.3.3-beta
====================
*Released date : April 18 2019*

# Concerned issues :
    #425 [Telemetry] Create telemetry deamon
    #731 [Trader] Allow to start from the previous execution last move
    #734 [Order] order_type is not consistent
    #740 [RunInAsyncMainLoop] problem with exchange commands
    #741 [WebInterface] add possibility to cancel orders
    #747 [Backtesting] prepare for multiple data formats
    #749 [Backtesting] impossible to display candles on specific timeframe from web interface
    #750 [OrderCreator] error when computing order price
    #751 [Backtesting] problem when saving config from web interface on backtesting
    #752 [WebInterface] candles display bug
    #756 [OrderManager] call_order_update_callback not called when exception in _update_order_status
    #785 [Metrics] community metrics display
    #792 [Web interface][Configuration] force display of parameters that are not in config.json

# New features :
    - Cancel orders from web interface
    - Community metrics though optionnal and anonymous telemetry
    - Added bot trader state save and recovery
    - Added telegram commands
    

# Bug fixes :
    - Fixed several bugs related to traders
    - Fixed an exchange timeout bug
    - Fixed web interface bugs
    - Fixed order creator bugs