### PR TITLE
allowed bot start with mistakes in exchange config

### DIFF
--- a/interfaces/trading_util.py
+++ b/interfaces/trading_util.py
@@ -41,7 +41,7 @@ def get_portfolio_holdings():
     simulated_currency_portfolio = {}
 
     for trader in traders:
-        if trader.enabled(trader.config):
+        if trader.is_enabled():
             trade_manager = trader.get_trades_manager()
 
             trader_currencies_values = get_bot().run_in_main_asyncio_loop(trade_manager.get_current_holdings_values())
@@ -62,7 +62,7 @@ def get_portfolio_current_value():
     has_simulated_trader = False
 
     for trader in traders:
-        if trader.enabled(trader.config):
+        if trader.is_enabled():
             trade_manager = trader.get_trades_manager()
 
             get_bot().run_in_main_asyncio_loop(trade_manager.update_portfolio_and_currencies_current_value())
@@ -229,7 +229,7 @@ def get_global_profitability():
     has_simulated_trader = False
 
     for trader in traders:
-        if trader.enabled(trader.config):
+        if trader.is_enabled():
             trade_manager = trader.get_trades_manager()
 
             # TODO : use other return values

--- a/trading/trader/trader.py
+++ b/trading/trader/trader.py
@@ -85,8 +85,14 @@ class Trader(Initializable):
         if self.enable:
             if self.previous_state_manager is not None:
                 self.load_previous_state_if_any()
-            await self.portfolio.initialize()
-            await self.trades_manager.initialize()
+            try:
+                await self.portfolio.initialize()
+                await self.trades_manager.initialize()
+            except Exception as e:
+                self.enable = False
+                self.logger.error(f"Error when initializing portfolio: {e}. "
+                                  f"{self.exchange.get_name()} trader disabled.")
+                self.logger.exception(e)
 
     def load_previous_state_if_any(self):
         # unused for real trader yet


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9078616/56810566-e457e900-6836-11e9-8fc5-3fd6fbd5d1c7.png)

This way on a config mistake the web interface still opens and if a simulator is activated, it can run also