### PR TITLE
[CI] Fix setup.py dependencies error

### DIFF
--- a/pre_requirements.txt
+++ b/pre_requirements.txt
@@ -1,4 +1,5 @@
 numpy
 Cython
 lxml
+urllib3==1.24.2
 Twisted # to be removed (python-binance)


### PR DESCRIPTION
![Capture](https://user-images.githubusercontent.com/10454670/56847153-07ca7480-68c7-11e9-82d9-07613f9ba833.PNG)
But urllib3 **1.25.1** is released.