### PR TITLE
fix kraken orders

### DIFF
--- a/trading/exchanges/rest_exchanges/rest_exchange.py
+++ b/trading/exchanges/rest_exchanges/rest_exchange.py
@@ -264,7 +264,8 @@ class RESTExchange(AbstractExchange, Initializable):
     def _ensure_order_details_completeness(order, order_required_fields=None):
         if order_required_fields is None:
             order_required_fields = [ecoc.ID.value, ecoc.TIMESTAMP.value, ecoc.SYMBOL.value, ecoc.TYPE.value,
-                                     ecoc.SIDE.value, ecoc.PRICE.value, ecoc.AMOUNT.value, ecoc.REMAINING.value]
+                                     ecoc.SIDE.value, ecoc.PRICE.value, ecoc.AMOUNT.value, ecoc.REMAINING.value,
+                                     ecoc.STATUS.value]
         return all(key in order for key in order_required_fields)
 
     def _log_error(self, error, order_type, symbol, quantity, price, stop_price):

--- a/trading/exchanges/rest_exchanges/rest_exchange.py
+++ b/trading/exchanges/rest_exchanges/rest_exchange.py
@@ -231,11 +231,6 @@ class RESTExchange(AbstractExchange, Initializable):
             if created_order[ecoc.PRICE.value] is None and price is not None:
                 created_order[ecoc.PRICE.value] = price
 
-            # on some exchange (ex: Kraken), orders are not not including status, add it manually to ensure uniformity
-            # since order status is required and this order just got created, consider it open
-            if created_order[ecoc.STATUS.value] is None:
-                created_order[ecoc.STATUS.value] = OrderStatus.OPEN.value
-
             return created_order
 
         except InsufficientFunds as e:

--- a/trading/exchanges/rest_exchanges/rest_exchange.py
+++ b/trading/exchanges/rest_exchanges/rest_exchange.py
@@ -225,9 +225,16 @@ class RESTExchange(AbstractExchange, Initializable):
                     created_order = await self.exchange_manager.get_exchange().get_order(created_order[ecoc.ID.value],
                                                                                          order_symbol)
 
-            # on some exchange, market order are not not including price, add it manually to ensure uniformity
+            # Missing order fields after retry handling
+
+            # on some exchange, market orders are not not including price, add it manually to ensure uniformity
             if created_order[ecoc.PRICE.value] is None and price is not None:
                 created_order[ecoc.PRICE.value] = price
+
+            # on some exchange (ex: Kraken), orders are not not including status, add it manually to ensure uniformity
+            # since order status is required and this order just got created, consider it open
+            if created_order[ecoc.STATUS.value] is None:
+                created_order[ecoc.STATUS.value] = OrderStatus.OPEN.value
 
             return created_order
 

--- a/trading/trader/trader.py
+++ b/trading/trader/trader.py
@@ -491,9 +491,8 @@ class Trader(Initializable):
                                           price=order["price"],
                                           timestamp=order["timestamp"])
 
-    @staticmethod
-    def update_order_with_exchange_order(exchange_order, order):
-        order.status = Trader.parse_status(exchange_order)
+    def update_order_with_exchange_order(self, exchange_order, order):
+        order.status = self.parse_status(exchange_order)
         order.total_cost = exchange_order[ExchangeConstantsOrderColumns.COST.value]
         order.filled_quantity = exchange_order[ExchangeConstantsOrderColumns.FILLED.value]
         order.filled_price = exchange_order[ExchangeConstantsOrderColumns.PRICE.value]
@@ -518,9 +517,16 @@ class Trader(Initializable):
     def parse_exchange_order_to_trade_instance(self, exchange_order, order):
         self.update_order_with_exchange_order(exchange_order, order)
 
-    @staticmethod
-    def parse_status(order):
-        return OrderStatus(order["status"])
+    def parse_status(self, order):
+        try:
+            return OrderStatus(order["status"])
+        except ValueError:
+            status = order["status"]
+            if status is None:
+                self.logger.debug(f"Received order status is {status}: using default value")
+            else:
+                self.logger.error(f"Incompatible received order status {status}: using default value")
+            return None
 
     @staticmethod
     def parse_order_type(order):


### PR DESCRIPTION
Not a fan of the fix lines 236/237 but since Kraken doesn't send the order status at creation and immediatly after, I see no other option to keep complient with the bot requirements