### PR TITLE
[Backtesting] Fixed backtesting recent trades

### DIFF
--- a/trading/exchanges/abstract_exchange.py
+++ b/trading/exchanges/abstract_exchange.py
@@ -56,7 +56,7 @@ class AbstractExchange:
         pass
 
     @abstractmethod
-    async def get_recent_trades(self, symbol, limit=50):
+    async def get_recent_trades(self, symbol, limit=50, candle_range=True):
         pass
 
     @abstractmethod

--- a/trading/exchanges/exchange_dispatcher.py
+++ b/trading/exchanges/exchange_dispatcher.py
@@ -173,14 +173,14 @@ class ExchangeDispatcher(AbstractExchange):
 
         return symbol_data.get_symbol_order_book()
 
-    async def get_recent_trades(self, symbol, limit=50):
+    async def get_recent_trades(self, symbol, limit=50, candle_range=True):
         symbol_data = self.get_symbol_data(symbol)
 
         if not self._web_socket_available() or not symbol_data.recent_trades_are_initialized():
             if not self._web_socket_available() or \
                     (self._web_socket_available() and self.exchange_web_socket.handles_recent_trades()):
                 symbol_data.init_recent_trades()
-            await self.exchange.get_recent_trades(symbol=symbol, limit=limit)
+            await self.exchange.get_recent_trades(symbol=symbol, limit=limit, candle_range=candle_range)
 
         return symbol_data.get_symbol_recent_trades()
 

--- a/trading/exchanges/rest_exchanges/rest_exchange.py
+++ b/trading/exchanges/rest_exchanges/rest_exchange.py
@@ -150,7 +150,7 @@ class RESTExchange(AbstractExchange, Initializable):
         order_book = await self.client.fetch_order_book(symbol, limit)
         self.get_symbol_data(symbol).update_order_book(order_book)
 
-    async def get_recent_trades(self, symbol, limit=50):
+    async def get_recent_trades(self, symbol, limit=50, candle_range=True):
         trades = await self.client.fetch_trades(symbol, limit=limit)
         self.get_symbol_data(symbol).update_recent_trades(trades)
 

--- a/trading/trader/modes/abstract_mode_creator.py
+++ b/trading/trader/modes/abstract_mode_creator.py
@@ -291,7 +291,7 @@ class AbstractTradingModeCreator:
 
     @staticmethod
     async def get_pre_order_data(exchange, symbol, portfolio):
-        last_prices = await exchange.execute_request_with_retry(exchange.get_recent_trades(symbol))
+        last_prices = await exchange.execute_request_with_retry(exchange.get_recent_trades(symbol, candle_range=False))
 
         used_last_prices = last_prices[-ORDER_CREATION_LAST_TRADES_TO_USE:]
 


### PR DESCRIPTION
Idea with recent trades, based on https://github.com/Drakkar-Software/OctoBot/pull/954 (backtesting only): 
* Added *candle_range* parameter (default value False) to exchange.get_recent_trades that is used by exchange simulator
  * When True: creates trades using the whole current candle from high to low and its timestamp
  * When False: creates trades using the close value of the previous candle only but the timestamp of the current candle

current candle: the candle directly following the previous candle in the smallest used timeframe (aka candle in construction in real situations)
previous candle: the last candle beeing pushed into evaluators (aka last complete candle)


* When creating an order, set the *candle_range* param to False and this will return recent trades using the close of the previous candle (closest possible to real life)
* When checking orders fill status, leave *candle_range* to its default value (False), this will return orders based on the whole candle, as if the time passed and this candle got constructed during backtesting just before being pushed into evaluators in the next round