### PR TITLE
#968 add not found and internal error handlers

### DIFF
--- a/interfaces/web/controllers/errors.py
+++ b/interfaces/web/controllers/errors.py
@@ -15,16 +15,16 @@
 #  License along with this library.
 
 
-def load_routes():
-    from . import errors
-    from . import tentacles
-    from . import backtesting
-    from . import commands
-    from . import configuration
-    from . import home
-    from . import dashboard
-    from . import trading
-    from . import logs
-    from . import interface_settings
-    from . import community
-    from . import terms
+from flask import render_template
+
+from interfaces.web import server_instance
+
+
+@server_instance.errorhandler(404)
+def not_found(_):
+    return render_template("404.html")
+
+
+@server_instance.errorhandler(500)
+def internal_error(_):
+    return render_template("500.html")

--- a/interfaces/web/static/js/common/common_handlers.js
+++ b/interfaces/web/static/js/common/common_handlers.js
@@ -1,0 +1,26 @@
+/*
+ * Drakkar-Software OctoBot
+ * Copyright (c) Drakkar-Software, All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library.
+ */
+
+$(document).ready(function() {
+    const backButton = $("#back-button");
+    if(backButton){
+        backButton.click(function (){
+            historyGoBack();
+        });
+    }
+});

--- a/interfaces/web/static/js/common/util.js
+++ b/interfaces/web/static/js/common/util.js
@@ -152,3 +152,7 @@ function getValueChangedFromRef(newObject, refObject) {
     }
     return changes;
 }
+
+function historyGoBack() {
+    window.history.back();
+}

--- a/interfaces/web/templates/404.html
+++ b/interfaces/web/templates/404.html
@@ -1,0 +1,18 @@
+{% extends "layout.html" %}
+{% block body %}
+<br>
+<div class="card">
+    <div class="card-header">
+        <h1>We are sorry, but this doesn't exist.</h1>
+    </div>
+    <div class="card-body">
+        You may have mistyped the address or the page may have moved.
+    </div>
+    <div class="card-footer">
+        <button type="button" id="back-button" class="btn btn-lg btn-primary waves-effect">Go back</button>
+    </div>
+</div>
+{% endblock %}
+{% block additional_scripts %}
+<script src="{{ url_for('static', filename='js/common/common_handlers.js') }}"></script>
+{% endblock additional_scripts %}

--- a/interfaces/web/templates/500.html
+++ b/interfaces/web/templates/500.html
@@ -1,0 +1,20 @@
+{% extends "layout.html" %}
+{% block body %}
+<br>
+<div class="card">
+    <div class="card-header">
+        <h1>We are sorry, but an unexpected error occurred.</h1>
+    </div>
+    <div class="card-body">
+        To fix this, please open an issue describing what happened on the
+        <a target="_blank" rel="noopener noreferrer" href="https://github.com/Drakkar-Software/OctoBot/issues"
+           class="btn btn-outline-white btn-md waves-effect">OctoBot issues report system.</a>
+    </div>
+    <div class="card-footer">
+        <button type="button" id="back-button" class="btn btn-lg btn-primary waves-effect">Go back</button>
+    </div>
+</div>
+{% endblock %}
+{% block additional_scripts %}
+<script src="{{ url_for('static', filename='js/common/common_handlers.js') }}"></script>
+{% endblock additional_scripts %}


### PR DESCRIPTION
Instead of default browser error pages:

when page not found:
![image](https://user-images.githubusercontent.com/9078616/63723594-22513200-c856-11e9-8cb0-c2279c4fd304.png)

when internal server error:
![image](https://user-images.githubusercontent.com/9078616/63723632-3bf27980-c856-11e9-8db5-cd41ddb785ba.png)
