### PR TITLE
fix error on last backtesting tick if order creation

### DIFF
--- a/evaluator/Updaters/global_price_updater.py
+++ b/evaluator/Updaters/global_price_updater.py
@@ -126,15 +126,15 @@ class GlobalPriceUpdater:
 
         await asyncio.gather(*update_tasks)
 
-        if update_tasks:
-            await self.trigger_symbols_finalize()
-
-        if self.in_backtesting and self.keep_running:
-            # force update orders in backtesting but can't update on the very last candle (no next candle
-            # to create recent trades from)
-            await self.update_backtesting_order_status()
-
         if self.keep_running:
+            if update_tasks:
+                await self.trigger_symbols_finalize()
+
+            if self.in_backtesting:
+                # force update orders in backtesting but can't update on the very last candle (no next candle
+                # to create recent trades from)
+                await self.update_backtesting_order_status()
+
             await self._update_pause(now)
 
     def _get_symbol_time_frame_next_update_time(self, symbol, time_frame):


### PR DESCRIPTION
the error:
![image](https://user-images.githubusercontent.com/9078616/64997977-a8571a80-d8e2-11e9-9a4b-cdb69d597f22.png)
problem: call finalize the backtesting is ended => if this last finalize triggers an order creation => error