### PR TITLE
[Docker] Fix arm build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update \
 ENV PATH="/opt/venv/bin:$PATH"
 
 COPY . .
-RUN pip install --upgrade pip==20.2.3 \
+RUN pip install --upgrade pip>=20.0.0 \
     && pip install Cython==0.29.21 \
     && pip install --extra-index-url https://www.piwheels.org/simple --extra-index-url https://www.tentacles.octobot.online/repository/octobot_pypi/simple --only-binary OctoBot-Commons --only-binary OctoBot-Channels --only-binary OctoBot-Evaluators --only-binary OctoBot-Backtesting --only-binary OctoBot-Trading --prefer-binary -r requirements.txt \
     && python setup.py install


### PR DESCRIPTION
pip==20.2.3 doesn't seem to exist on arm64 (see [builder ci](https://travis-ci.com/github/Drakkar-Software/OctoBot-Builder/jobs/386631280))