### PR TITLE
handle no trading mode in community manager

### DIFF
--- a/octobot/community/community_manager.py
+++ b/octobot/community/community_manager.py
@@ -194,7 +194,9 @@ class CommunityManager:
     def _get_eval_config(self):
         tentacle_setup_config = self.octobot_api.get_tentacles_setup_config()
         # trading mode
-        config_eval = [self.octobot_api.get_trading_mode().get_name()]
+        config_eval = []
+        if (trading_mode := self.octobot_api.get_trading_mode()) is not None:
+            config_eval.append(trading_mode.get_name())
 
         # strategies
         for strategy in evaluator_api.get_evaluator_classes_from_type(


### PR DESCRIPTION
fixes https://github.com/Drakkar-Software/OctoBot-Launcher/issues/54 
> CommunityManager Exception when handling community registration: 'NoneType' object has no attribute 'get_name'