### PR TITLE
[Requirements] Fix chardet conflit by using aiohttp master

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,6 @@ Async-Channel==2.0.7
 colorlog==4.2.1
 yarl==1.1.0
 idna<2.9,>=2.5
-aiohttp==3.7.3
+# aiohttp==3.7.3
+git+https://github.com/aio-libs/aiohttp@master
 requests==2.25.1


### PR DESCRIPTION
More details in : https://github.com/Drakkar-Software/OctoBot/runs/1605637436?check_suite_focus=true#step:8:2848

To be removed when aiohttp==3.7.4 is released.