### PR TITLE
[BacktestingTests] do not cythonize _handle_results to prevent warn

### DIFF
--- a/octobot/backtesting/abstract_backtesting_test.pxd
+++ b/octobot/backtesting/abstract_backtesting_test.pxd
@@ -26,5 +26,4 @@ cdef class AbstractBacktestingTest:
                                         object tentacles_setup_config,
                                         dict config)
 
-    cdef void _handle_results(self, object independent_backtesting, object profitability)
     cdef void _register_only_strategy(self, object strategy_evaluator_class)


### PR DESCRIPTION
fixes 
![image](https://user-images.githubusercontent.com/9078616/111066472-92b6b700-84bf-11eb-8b9d-aca2fd3c9161.png)

ex in: https://github.com/Drakkar-Software/OctoBot-Tentacles/runs/2106148765?check_suite_focus=true#step:7:221