### PR TITLE
Disable Rust dependencies while building cryptography for Docker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -72,13 +72,13 @@ jobs:
         with:
           driver: docker
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
+      # - name: Cache Docker layers
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: /tmp/.buildx-cache
+      #     key: ${{ runner.os }}-buildx-${{ github.sha }}
+      #     restore-keys: |
+      #       ${{ runner.os }}-buildx-
 
       - name: Login to DockerHub
         if: github.event_name == 'push'
@@ -116,8 +116,8 @@ jobs:
           tags: ${{ env.IMAGE }}:${{ env.LATEST }}
           build-args: |
             TENTACLES_URL_TAG=${{ env.LATEST }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          # cache-from: type=local,src=/tmp/.buildx-cache
+          # cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Docker build test container
         if: github.event_name != 'push'
@@ -155,8 +155,8 @@ jobs:
           tags: ${{ env.IMAGE }}:${{ env.LATEST }}
           build-args: |
             TENTACLES_URL_TAG=${{ env.LATEST }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          # cache-from: type=local,src=/tmp/.buildx-cache
+          # cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Build and push on tag
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
@@ -171,8 +171,8 @@ jobs:
             ${{ env.IMAGE }}:${{ env.LATEST }}
             ${{ env.IMAGE }}:${{ env.STABLE }}
             ${{ env.IMAGE }}:${{ env.VERSION }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
+          # cache-from: type=local,src=/tmp/.buildx-cache
+          # cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Image digest
         run: echo ${{ steps.docker_build_and_psuh.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -70,15 +70,16 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@master
         with:
-          driver: docker
+          driver: docker-container
+          use: true
 
-      # - name: Cache Docker layers
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: /tmp/.buildx-cache
-      #     key: ${{ runner.os }}-buildx-${{ github.sha }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-buildx-
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
 
       - name: Login to DockerHub
         if: github.event_name == 'push'
@@ -109,15 +110,15 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm/v7
           # Using "load: true" forces the docker driver.
-          # Not necessary here, because we set it before.
-          # ref: https://stackoverflow.com/a/64560710/9944075
+          # Unfortunately, the "docker" driver does not support
+          # multi-platform builds.
           # load: true
           push: false
           tags: ${{ env.IMAGE }}:${{ env.LATEST }}
           build-args: |
             TENTACLES_URL_TAG=${{ env.LATEST }}
-          # cache-from: type=local,src=/tmp/.buildx-cache
-          # cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Docker build test container
         if: github.event_name != 'push'
@@ -155,8 +156,8 @@ jobs:
           tags: ${{ env.IMAGE }}:${{ env.LATEST }}
           build-args: |
             TENTACLES_URL_TAG=${{ env.LATEST }}
-          # cache-from: type=local,src=/tmp/.buildx-cache
-          # cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Build and push on tag
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
@@ -171,8 +172,8 @@ jobs:
             ${{ env.IMAGE }}:${{ env.LATEST }}
             ${{ env.IMAGE }}:${{ env.STABLE }}
             ${{ env.IMAGE }}:${{ env.VERSION }}
-          # cache-from: type=local,src=/tmp/.buildx-cache
-          # cache-to: type=local,dest=/tmp/.buildx-cache
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Image digest
         run: echo ${{ steps.docker_build_and_psuh.outputs.digest }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: OctoBot-Docker
 on:
   push:
     branches:
-      - 'master'
-      - 'dev'
+      - "master"
+      - "dev"
     tags:
-      - '*'
+      - "*"
   pull_request:
 
 jobs:
@@ -58,10 +58,19 @@ jobs:
         run: exit 1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        id: qemu-setup
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: all
+
+      - name: Print available platforms
+        run: echo ${{ steps.qemu.outputs.platforms }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        id: buildx
+        uses: docker/setup-buildx-action@master
+        with:
+          driver: docker
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -92,14 +101,17 @@ jobs:
         if: github.event_name == 'push' && steps.wait-for-main-build.outputs.conclusion == 'failure'
         run: exit 1
 
-      - name: Build and push latest
+      - name: Build latest
         if: github.event_name != 'push'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@master
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
           platforms: linux/amd64,linux/arm/v7
-          load: true
+          # Using "load: true" forces the docker driver.
+          # Not necessary here, because we set it before.
+          # ref: https://stackoverflow.com/a/64560710/9944075
+          # load: true
           push: false
           tags: ${{ env.IMAGE }}:${{ env.LATEST }}
           build-args: |
@@ -134,7 +146,7 @@ jobs:
 
       - name: Build and push latest
         if: github.event_name == 'push' && !startsWith(github.ref, 'refs/tags') && github.ref == 'refs/heads/dev'
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@master
         with:
           context: .
           builder: ${{ steps.buildx.outputs.name }}
@@ -148,7 +160,7 @@ jobs:
 
       - name: Build and push on tag
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@master
         with:
           context: .
           file: ./Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,12 @@ FROM python:3.8-slim-buster AS base
 # requires rustc is required to build cryptography wheel
 RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential git gcc libffi-dev libssl-dev libxml2-dev libxslt1-dev libxslt-dev libjpeg62-turbo-dev zlib1g-dev \
-    && apt-get install -y rustc \
+    # && apt-get install -y rustc \
     && python -m venv /opt/venv
 
 # Make sure we use the virtualenv:
+ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1 
+
 ENV PATH="/opt/venv/bin:$PATH"
 
 COPY . .


### PR DESCRIPTION
## Summary

Fixes ARM builds for Docker (using one of two available approaches, see details below) (related to https://github.com/Drakkar-Software/OctoBot/issues/1579 and https://github.com/Drakkar-Software/OctoBot/pull/1606).

Solve the issue: #1579

## Changelog

  - Removes Rust dependencies for Python's cryptography package while building Docker image.

## What's new?

Due to cryptography's recent dependencies on Rust (https://github.com/pyca/cryptography/issues/5771), Raspberry Pi's arm/v7 platform (among others) became unsupported. In order to fix that, there are currently two available approaches:

* Disable Rust while building cryptography with the environment variable `CRYPTOGRAPHY_DONT_BUILD_RUST=1` (chosen in this case)
  * Keeps cryptography up to date
  * I couldn't really find the downsides of disabling Rust
* Use an older version of cryptography (`2.6.1` works fine for me in other projects)
  * Cryptography is outdated, can lead to security issues

You can see that when I've tried to build it using the Dockerfile I've customized it seems that [the build has gone OK](https://github.com/gabriel-milan/OctoBot/pull/3/checks?check_run_id=2175721455) but, unfortunately, there's this issue:

```
Error: buildx call failed with: error: failed to solve: rpc error: code = Unknown desc = docker exporter does not currently support exporting manifest lists
``` 

Fortunately, this isn't related to the Docker image itself, but this: https://github.com/docker/buildx/issues/59.

The purpose of this PR is to find out if this change to the Dockerfile is acceptable. If so, I can implement what is missing.