### PR TITLE
[CI] Fix scoped GITHUB_ACTION usage

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,7 +47,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-tentacles
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTH_TOKEN }}
           checkName: "ubuntu-latest - Python 3.8 - upload tentacles"
           ref: ${{ github.ref }}
           repo: OctoBot-Tentacles
@@ -83,7 +83,7 @@ jobs:
         uses: fountainhead/action-wait-for-check@v1.0.0
         id: wait-for-main-build
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.AUTH_TOKEN }}
           checkName: "Done"
           ref: ${{ github.sha }}
           timeoutSeconds: 3600

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
       uses: fountainhead/action-wait-for-check@v1.0.0
       id: wait-for-build
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.AUTH_TOKEN }}
         checkName: "ubuntu-latest - Python 3.8 - upload tentacles"
         ref: ${{ github.ref }}
         repo: OctoBot-Tentacles

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Create release on OctoBot-Tentacles
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.AUTH_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
         release_name: Version - ${GITHUB_REF##*/}
@@ -29,7 +29,7 @@ jobs:
       uses: fountainhead/action-wait-for-check@v1.0.0
       id: wait-for-build
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.AUTH_TOKEN }}
         checkName: "Done"
         ref: ${{ github.sha }}
         timeoutSeconds: 3600
@@ -41,7 +41,7 @@ jobs:
     - name: Create release on OctoBot-Binary
       uses: actions/create-release@v1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.AUTH_TOKEN }}
       with:
         tag_name: ${{ github.ref }}
         release_name: Version - ${GITHUB_REF##*/}


### PR DESCRIPTION
Inspired from https://github.com/actions/create-release/issues/103

Should fix "Resource not accessible by integration" error when creating release or waiting for build status.

AUTH_TOKEN is a generated token from my account.