### PR TITLE
[Install] Fix exception when installing OctoBot from pip or setup.py

### DIFF
--- a/octobot/__init__.pxd
+++ b/octobot/__init__.pxd
@@ -67,21 +67,3 @@ def get_bot():
 
 def get_config():
     return global_config
-
-
-from octobot cimport octobot
-
-from octobot.octobot cimport (
-    OctoBot
-)
-
-from octobot cimport octobot_backtesting_factory
-
-from octobot.octobot_backtesting_factory cimport (
-    OctoBotBacktestingFactory,
-)
-
-__all__ = [
-    "OctoBot",
-    "OctoBotBacktestingFactory",
-]

--- a/octobot/__init__.py
+++ b/octobot/__init__.py
@@ -15,29 +15,9 @@
 #  License along with this library.
 
 from __future__ import print_function
-# prevents distutils_patch.py:26: UserWarning: Distutils was imported before Setuptools. This usage is discouraged
-# and may exhibit undesirable behaviors or errors. Please use Setuptools' objects directly or at least import Setuptools
-# first
-import setuptools
-from distutils.version import LooseVersion
 import os
 import sys
 
-MIN_TENTACLE_MANAGER_VERSION = "1.0.10"
-
-# check compatible tentacle manager
-try:
-    from octobot_tentacles_manager import VERSION
-
-    if LooseVersion(VERSION) < MIN_TENTACLE_MANAGER_VERSION:
-        print("OctoBot requires OctoBot-Tentacles-Manager in a minimum version of " + MIN_TENTACLE_MANAGER_VERSION +
-              " you can install and update OctoBot-Tentacles-Manager using the following command: "
-              "python3 -m pip install -U OctoBot-Tentacles-Manager", file=sys.stderr)
-        sys.exit(-1)
-except ImportError:
-    print("OctoBot requires OctoBot-Tentacles-Manager, you can install it using "
-          "python3 -m pip install -U OctoBot-Tentacles-Manager", file=sys.stderr)
-    sys.exit(-1)
 
 # binary tentacle importation
 sys.path.append(os.path.dirname(sys.executable))
@@ -66,21 +46,3 @@ def get_bot():
 
 def get_config():
     return global_config
-
-
-from octobot import octobot
-
-from octobot.octobot import (
-    OctoBot
-)
-
-from octobot import octobot_backtesting_factory
-
-from octobot.octobot_backtesting_factory import (
-    OctoBotBacktestingFactory,
-)
-
-__all__ = [
-    "OctoBot",
-    "OctoBotBacktestingFactory",
-]

--- a/octobot/constants.py
+++ b/octobot/constants.py
@@ -16,9 +16,6 @@
 import os
 import pathlib
 
-import octobot_commons.constants as commons_constants
-import octobot_tentacles_manager.constants as tentacles_manager_constants
-
 PROJECT_NAME = "OctoBot"
 AUTHOR = "DrakkarSoftware"
 SHORT_VERSION = "0.4.0"  # major.minor.revision
@@ -60,25 +57,30 @@ ENV_TENTACLE_CATEGORY = "TENTACLE_CATEGORY"
 ENV_COMPILED_TENTACLES_SUBCATEGORY = "COMPILED_TENTACLES_SUBCATEGORY"
 TENTACLES_REQUIRED_VERSION = f"{os.getenv(ENV_TENTACLES_URL_TAG, LONG_VERSION)}"
 # url ending example: 	tentacles/officials/packages/full/base/latest/any_platform.zip
-DEFAULT_TENTACLES_URL = os.getenv(
-    ENV_TENTACLES_URL,
-    f"{OCTOBOT_ONLINE}/{REPOSITORY}/"
-    f"{os.getenv(ENV_TENTACLES_REPOSITORY, TENTACLES_REPOSITORY)}/"
-    f"{os.getenv(ENV_TENTACLES_PACKAGES_SOURCE, OFFICIALS)}/"
-    f"{os.getenv(ENV_TENTACLES_PACKAGES_TYPE, TENTACLE_PACKAGES)}/"
-    f"{os.getenv(ENV_TENTACLE_CATEGORY, TENTACLE_CATEGORY)}/"
-    f"{os.getenv(ENV_TENTACLE_PACKAGE_NAME, TENTACLE_PACKAGE_NAME)}/"
-    f"{TENTACLES_REQUIRED_VERSION if TENTACLES_REQUIRED_VERSION else LONG_VERSION}/"
-    f"{tentacles_manager_constants.ANY_PLATFORM_FILE_NAME}.{tentacles_manager_constants.TENTACLES_PACKAGE_FORMAT}"
-)
-DEFAULT_COMPILED_TENTACLES_URL = os.getenv(
-    ENV_COMPILED_TENTACLES_URL,
-    f"{OCTOBOT_ONLINE}/{REPOSITORY}/{TENTACLES_REPOSITORY}/"
-    f"{os.getenv(ENV_TENTACLES_PACKAGES_SOURCE, OFFICIALS)}/"
-    f"{os.getenv(ENV_COMPILED_TENTACLES_PACKAGES_TYPE, TENTACLE_PACKAGES)}/"
-    f"{os.getenv(ENV_COMPILED_TENTACLES_CATEGORY, COMPILED_TENTACLE_CATEGORY)}/"
-    f"{os.getenv(ENV_COMPILED_TENTACLES_SUBCATEGORY, '')}"
-)
+try:
+    import octobot_tentacles_manager.constants as tentacles_manager_constants
+    DEFAULT_TENTACLES_URL = os.getenv(
+        ENV_TENTACLES_URL,
+        f"{OCTOBOT_ONLINE}/{REPOSITORY}/"
+        f"{os.getenv(ENV_TENTACLES_REPOSITORY, TENTACLES_REPOSITORY)}/"
+        f"{os.getenv(ENV_TENTACLES_PACKAGES_SOURCE, OFFICIALS)}/"
+        f"{os.getenv(ENV_TENTACLES_PACKAGES_TYPE, TENTACLE_PACKAGES)}/"
+        f"{os.getenv(ENV_TENTACLE_CATEGORY, TENTACLE_CATEGORY)}/"
+        f"{os.getenv(ENV_TENTACLE_PACKAGE_NAME, TENTACLE_PACKAGE_NAME)}/"
+        f"{TENTACLES_REQUIRED_VERSION if TENTACLES_REQUIRED_VERSION else LONG_VERSION}/"
+        f"{tentacles_manager_constants.ANY_PLATFORM_FILE_NAME}.{tentacles_manager_constants.TENTACLES_PACKAGE_FORMAT}"
+    )
+    DEFAULT_COMPILED_TENTACLES_URL = os.getenv(
+        ENV_COMPILED_TENTACLES_URL,
+        f"{OCTOBOT_ONLINE}/{REPOSITORY}/{TENTACLES_REPOSITORY}/"
+        f"{os.getenv(ENV_TENTACLES_PACKAGES_SOURCE, OFFICIALS)}/"
+        f"{os.getenv(ENV_COMPILED_TENTACLES_PACKAGES_TYPE, TENTACLE_PACKAGES)}/"
+        f"{os.getenv(ENV_COMPILED_TENTACLES_CATEGORY, COMPILED_TENTACLE_CATEGORY)}/"
+        f"{os.getenv(ENV_COMPILED_TENTACLES_SUBCATEGORY, '')}"
+    )
+except ImportError:
+    pass
+
 DEFAULT_TENTACLES_PACKAGE_NAME = "OctoBot-Default-Tentacles"
 
 # logs
@@ -108,8 +110,12 @@ DEFAULT_PROFILE_FILE = f"{CONFIG_FOLDER}/default_profile.json"
 DEFAULT_PROFILE_AVATAR_FILE_NAME = "default_profile.png"
 DEFAULT_PROFILE_AVATAR = f"{CONFIG_FOLDER}/{DEFAULT_PROFILE_AVATAR_FILE_NAME}"
 LOGGING_CONFIG_FILE = f"{CONFIG_FOLDER}/logging_config.ini"
-USER_LOCAL_LOGGING_CONFIG_FILE = f"{commons_constants.USER_FOLDER}/logging_config.ini"
 LOG_FILE = f"{LOGS_FOLDER}/{PROJECT_NAME}.log"
+try:
+    import octobot_commons.constants as commons_constants
+    USER_LOCAL_LOGGING_CONFIG_FILE = f"{commons_constants.USER_FOLDER}/logging_config.ini"
+except ImportError:
+    pass
 
 # Optimizer
 OPTIMIZER_FORCE_ASYNCIO_DEBUG_OPTION = False


### PR DESCRIPTION
OctoBot should check after installing that OctoBot-Tentacles-Manager and OctoBot-Backtesting are installed instead of before processing dependencies.

## How to reproduce : 
- pip3 install OctoBot==0.4.0b6 with a fresh python environment
```bash
OctoBot requires OctoBot-Tentacles-Manager, you can install it using python3 -m pip install -U OctoBot-Tentacles-Manager
```

## Expected
-  Pip or setup.py install without raising an exception
-  Raise when OctoBot is installed an run without OctoBot-Tentacles-Manager installed


