### PR TITLE
WIP [Python3.9] prevent interpreter shutdown error

### DIFF
--- a/octobot/task_manager.py
+++ b/octobot/task_manager.py
@@ -69,6 +69,7 @@ class TaskManager:
         self.loop_forever_thread = threading.Thread(target=self.run_bot_in_thread, args=(coroutine,),
                                                     name=f"OctoBot Main Thread")
         self.loop_forever_thread.start()
+        self.loop_forever_thread.join()
 
     def stop_tasks(self):
         self.logger.info("Stopping tasks...")


### PR DESCRIPTION
Fixes the interpreter shutdown error however prevents the bot from stopping, hence the WIP

It looks like the issue is that threadpoolexecutors are not daemons anymore and need to be shutdown (https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor.shutdown)