### PR TITLE
Fix cannot import name 'Log' from 'distutils.log'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ idna<2.9,>=2.5
 requests==2.25.1
 packaging==21.3
 python-dotenv==0.21.0
+setuptools<65.6 # Added because the distutils.log.Log class was removed in setuptools >= 65.6. Should be remove when bumping numpy. 
 
 # Community
 websockets


### PR DESCRIPTION
Inspired from https://github.com/pypa/setuptools/issues/3693 and https://github.com/numpy/numpy/issues/22623