### PR TITLE
Migrate cloud to astrolab

### DIFF
--- a/.do/deploy.template.yaml
+++ b/.do/deploy.template.yaml
@@ -1,9 +1,0 @@
-spec:
-  name: octobot
-  services:
-  - dockerfile_path: Dockerfile
-    git:
-      branch: master
-      repo_clone_url: https://github.com/Drakkar-Software/OctoBot
-    name: octobot-web
-    http_port: 5001

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Octobot's main feature is **evolution** : you can [install](https://www.octobot.
 ## Installation
 OctoBot's installation is **very simple**... because it is **very documented** ! See the [installation guides](https://www.octobot.online/guides/#installation) for more info.
 
+#### One click deployment
+Register to [Astrolab](https://www.astrolab.cloud/) then click `my bots` then `deploy now`.
+
 #### [With executable](https://www.octobot.info/installation/with-binary)
 Follow the [2 steps installation guide](https://www.octobot.online/executable_installation/) 
 
@@ -89,15 +92,6 @@ cd OctoBot
 python3 -m pip install -Ur requirements.txt
 python3 start.py
 ```
-
-#### One click deployment
-Follow the [Digital Ocean installation guide](https://octobot.click/gh-do-install) 
-
-In short :
-
-[![Deploy to DO](https://mp-assets1.sfo2.digitaloceanspaces.com/deploy-to-do/do-btn-blue.svg)](https://octobot.click/gh-do-deploy)
-
-- Get 60-day free Digital Ocean hosting by registering with [OctoBot referral link](https://m.do.co/c/40c9737100b1).
 
 ## Exchanges
 [![Binance](../assets/binance-logo.png)](https://octobot.click/gh-binance)


### PR DESCRIPTION
To be merged when cloud OctoBot is available on astrolab.cloud.

@GuillaumeDSM do you think we should first add a link to beta.astrolab.cloud?