### PR TITLE
Improve optimizer settings, live metadata and fix position size calculation

### DIFF
--- a/octobot/storage/trading_metadata.py
+++ b/octobot/storage/trading_metadata.py
@@ -179,7 +179,7 @@ async def _get_multi_exchange_data(exchange_managers, is_backtesting):
                 values.pop("available", None)
         if exchange_manager.is_future:
             for position in trading_api.get_positions(exchange_manager):
-                exchange_end_portfolio[position.get_currency()]["position"] = float(position.quantity)
+                exchange_end_portfolio[position.get_currency()]["position"] = float(position.single_contract_value * position.size)
         for exchange_portfolio, portfolio in zip((exchange_origin_portfolio, exchange_end_portfolio),
                                                  (origin_portfolio, end_portfolio)):
             for currency, value_dict in exchange_portfolio.items():

--- a/octobot/storage/trading_metadata.py
+++ b/octobot/storage/trading_metadata.py
@@ -163,10 +163,11 @@ async def _get_multi_exchange_data(exchange_managers, is_backtesting):
             for exchange_manager in exchange_managers
         )
     else:
-        start_time = exchange_managers[0].exchange.get_exchange_current_time()
+        start_time = trades[0].creation_time if trades else exchange_managers[0].exchange.get_exchange_current_time()
         end_time = -1
     origin_portfolio = {}
     end_portfolio = {}
+    # handle live origin_portfolio
     for exchange_manager in exchange_managers:
         try:
             exchange_origin_portfolio = trading_api.get_origin_portfolio(exchange_manager, as_decimal=False)
@@ -241,8 +242,10 @@ async def _get_single_exchange_data(exchange_manager, trading_mode, run_start_ti
     backtesting_only_metadata = {
         common_enums.BacktestingMetadata.ID.value: run_dbs_identifier.backtesting_id,
         common_enums.BacktestingMetadata.OPTIMIZATION_CAMPAIGN.value: run_dbs_identifier.optimization_campaign_name,
-        common_enums.BacktestingMetadata.USER_INPUTS.value: formatted_user_inputs,
-    } if is_backtesting else {}
+            common_enums.BacktestingMetadata.USER_INPUTS.value: formatted_user_inputs,
+    } if is_backtesting else {
+        common_enums.BacktestingMetadata.ID.value: run_dbs_identifier.live_id,
+        }
     return {
         **backtesting_only_metadata,
         **{


### PR DESCRIPTION
requires https://github.com/Drakkar-Software/OctoBot-Trading/pull/797 for the `single_contract_value` position attribute

as discussed.
regarding your question:
- why those changes in optimizer settings ?
If one of the input settings is an empty string, it will set it to default values now