### PR TITLE
[Optimizer] properly handle multiple and single options

### DIFF
--- a/octobot/strategy_optimizer/strategy_design_optimizer.py
+++ b/octobot/strategy_optimizer/strategy_design_optimizer.py
@@ -53,6 +53,7 @@ class ConfigTypes(enum.Enum):
     NUMBER = "number"
     BOOLEAN = "boolean"
     OPTIONS = "options"
+    MULTIPLE_OPTIONS = "multiple-options"
     UNKNOWN = "unknown"
 
 
@@ -75,6 +76,7 @@ class StrategyDesignOptimizer:
     CONFIG_USER_INPUTS = "user_inputs"
     CONFIG_FILTER_SETTINGS = "filters_settings"
     CONFIG_VALUE = "value"
+    CONFIG_TYPE = "type"
     CONFIG_TENTACLE = "tentacle"
     CONFIG_NESTED_TENTACLE_SEPARATOR = "_------_"
     CONFIG_TYPE = "type"
@@ -791,8 +793,13 @@ class StrategyDesignOptimizer:
         values = []
         try:
             if config_element[self.CONFIG_ENABLED]:
+                if config_element[self.CONFIG_TYPE] is ConfigTypes.MULTIPLE_OPTIONS:
+                    self._generate_possible_multiple_options_values(
+                    possible_values=values,
+                    config_element_values=config_element[self.CONFIG_VALUE][self.CONFIG_VALUE],
+                    )
                 if config_element[self.CONFIG_TYPE] is ConfigTypes.OPTIONS:
-                    values = [[value] for value in config_element[self.CONFIG_VALUE][self.CONFIG_VALUE]]
+                    values = [value for value in config_element[self.CONFIG_VALUE][self.CONFIG_VALUE]]
                 if config_element[self.CONFIG_TYPE] is ConfigTypes.BOOLEAN:
                     values = config_element[self.CONFIG_VALUE][self.CONFIG_VALUE]
                 if config_element[self.CONFIG_TYPE] is ConfigTypes.NUMBER:
@@ -825,7 +832,28 @@ class StrategyDesignOptimizer:
         while current <= d_stop:
             yield return_type(current)
             current += d_step
-
+            
+    def _generate_possible_multiple_options_values(
+        self,
+        possible_values: list,
+        config_element_values,
+        parent_values: list | None = None,
+    ):
+        if parent_values is None:
+            parent_values = []
+        for combinable_value in config_element_values:
+            if combinable_value not in parent_values:
+                new_parent_values = parent_values + [combinable_value]
+                # sort to check uniqueness 
+                new_parent_values.sort()
+                if new_parent_values not in possible_values:
+                    possible_values.append(new_parent_values)
+                self._generate_possible_multiple_options_values(
+                    possible_values,
+                    config_element_values,
+                    new_parent_values,
+                )
+                
     @staticmethod
     def get_accurate_number_type(*values):
         return int if all(isinstance(e, int) for e in values) else float
@@ -841,6 +869,9 @@ class StrategyDesignOptimizer:
             }
 
     def _get_config_type(self, value):
+        config_type = value.get(self.CONFIG_TYPE)
+        if config_type:
+            return ConfigTypes(config_type)
         config_values = value[self.CONFIG_VALUE]
         if isinstance(config_values, list):
             if not config_values:

--- a/tests/unit_tests/strategy_optimizer/test_strategy_design_optimizer.py
+++ b/tests/unit_tests/strategy_optimizer/test_strategy_design_optimizer.py
@@ -50,14 +50,18 @@ async def test_generate_and_save_strategy_optimizer_runs(optimizer_inputs):
             mock.patch.object(strategy_optimizer.StrategyDesignOptimizer, "shuffle_and_select_runs", mock.Mock(
                 side_effect=lambda *args, **_: args[0]
             )) as shuffle_and_select_runs_mock:
-        assert await bot_module_api.generate_and_save_strategy_optimizer_runs(
+        generated_runs = await bot_module_api.generate_and_save_strategy_optimizer_runs(
             trading_mode,
             tentacles_setup_config,
             optimizer_settings
-        ) == EXPECTED_RUNS_FROM_MOCK
+        )
+        expected_run_list = list(EXPECTED_RUNS_FROM_MOCK.values())
+        assert len(expected_run_list) == len(generated_runs)
+        for run in generated_runs.values():
+            assert run in expected_run_list
         create_identifier_mock.assert_called_once()
         shuffle_and_select_runs_mock.assert_called_once()
-        _save_run_schedule_mock.assert_awaited_once_with(EXPECTED_RUNS_FROM_MOCK)
+        _save_run_schedule_mock.assert_awaited_once_with(generated_runs)
 
 
 async def test_resume_unknown_mode(optimizer_inputs):


### PR DESCRIPTION
You will need to adapt private optimizer code:
for ConfigTypes.MULTIPLE_OPTIONS to work properly (multiple-options user inputs), the strategy design config generated by the frontend needs to pass the config "type": ConfigTypes.MULTIPLE_OPTIONS.value  (config_element[self.CONFIG_TYPE] == ConfigTypes.MULTIPLE_OPTIONS.value)

all other ConfigTypes are supported to set via "type" as well, but should not be saved/sent via api as we can infer them still

