### PR TITLE
[TaskManager] run backtesting in main thread when RUN_IN_MAIN_THREAD is set

### DIFF
--- a/octobot/constants.py
+++ b/octobot/constants.py
@@ -109,6 +109,7 @@ TRACKING_ID = os.getenv("TRACKING_ID", "eoe1stwyun" if IS_DEMO else "eoe06soct7"
 TO_DOWNLOAD_PROFILES = os.getenv("TO_DOWNLOAD_PROFILES", None)
 # Profiles to force select at startup, identified by profile id, download url or name
 FORCED_PROFILE = os.getenv("FORCED_PROFILE", None)
+RUN_IN_MAIN_THREAD = os.getenv("RUN_IN_MAIN_THREAD", False)
 
 OCTOBOT_BINARY_PROJECT_NAME = "OctoBot-Binary"
 

--- a/octobot/task_manager.py
+++ b/octobot/task_manager.py
@@ -68,12 +68,16 @@ class TaskManager:
         self.logger.debug("Stopped OctoBot main loop")
 
     def run_forever(self, coroutine):
-        self.loop_forever_thread = threading.Thread(target=self.run_bot_in_thread, args=(coroutine,),
-                                                    name=f"OctoBot Main Thread")
-        self.loop_forever_thread.start()
-        if sys.version_info.minor >= 9:
-            # only required for python 3.9 +
-            self.loop_forever_thread.join()
+        if constants.RUN_IN_MAIN_THREAD:
+            self.run_bot_in_thread(coroutine)
+        else:
+            self.loop_forever_thread = threading.Thread(
+                target=self.run_bot_in_thread, args=(coroutine,),
+                name="OctoBot Main Thread")
+            self.loop_forever_thread.start()
+            if sys.version_info.minor >= 9:
+                # only required for python 3.9 +
+                self.loop_forever_thread.join()
 
     def stop_tasks(self, stop_octobot=True):
         self.logger.info("Stopping tasks...")


### PR DESCRIPTION
adds a more convenient way to use the profiler