### PR TITLE
[Infra] Add node deployment infrastructure with INSTALL_DEFAULT_TENTACLES support

### DIFF
--- a/infra/node/README.md
+++ b/infra/node/README.md
@@ -2,7 +2,7 @@
 
 Deploys an inventory of OctoBot Node instances with zero-downtime rolling updates.
 
-**Stack per node:** OctoBot Node + optional Nginx (reverse proxy) + optional Tor (SOCKS5 proxy) + optional PostgreSQL (on master)
+**Stack per node:** OctoBot Node + optional Nginx (reverse proxy) + optional Tor (SOCKS5 proxy) + optional PostgreSQL (on master) + optional wallet services (Monero, Bitcoin, Ethereum)
 
 ## Prerequisites
 
@@ -67,6 +67,9 @@ Shared defaults live in `roles/octobot/defaults/main.yml`. Overrides go in `inve
 |---|---|---|
 | `enable_hardening` | `false` | Apply OS and SSH hardening via [devsec.hardening](https://github.com/dev-sec/ansible-collection-hardening) |
 | `enable_tor` | `false` | Build and deploy a Tor SOCKS5 proxy sidecar; routes exchange traffic through Tor |
+| `enable_monero_wallet` | `false` | Deploy Monero daemon + wallet RPC sidecar |
+| `enable_bitcoin_wallet` | `false` | Deploy Bitcoin Core with wallet support |
+| `enable_eth_wallet` | `false` | Deploy Geth (go-ethereum) node with HTTP and WebSocket RPC |
 | `enable_replica_mode` | `false` | Deploy PostgreSQL on master, connect all nodes via `SCHEDULER_POSTGRES_URL` |
 | `enable_nginx` | `false` | Deploy Nginx reverse proxy with SSL termination in front of OctoBot |
 | `expose_web_ui` | `false` | Expose the OctoBot web UI (port 5001). When `false`, only the Node API port is exposed and nginx returns 403 for web routes |
@@ -85,6 +88,7 @@ Secrets are passed as Ansible variables (via `--extra-vars`, `vars.yml`, or any 
 | `admin_username` | Admin email (enforced non-default in production) |
 | `admin_password` | Admin password (enforced non-default in production) |
 | `postgres_password` | PostgreSQL password (only when `enable_replica_mode: true`) |
+| `bitcoin_rpc_password` | Bitcoin Core RPC password (only when `enable_bitcoin_wallet: true`) |
 
 Optional task encryption keys:
 
@@ -158,6 +162,50 @@ all:
 ### Tor Proxy
 
 When `enable_tor: true`, a custom Tor SOCKS5 proxy container (Alpine-based, ~8MB) is built and deployed alongside OctoBot. The environment variable `EXCHANGE_SOCKS_PROXY_AUTHENTICATED_URL=socks5h://tor:9050` routes all exchange (CCXT) traffic through the Tor network. The `USE_AUTHENTICATED_EXCHANGE_REQUESTS_ONLY_PROXY=False` flag ensures both authenticated and public requests are proxied.
+
+### Wallet Services
+
+Three optional wallet services can be deployed alongside OctoBot. Each runs in its own isolated Docker network and persists blockchain/wallet data in named volumes.
+
+#### Monero (`enable_monero_wallet: true`)
+
+Deploys a Monero daemon (`monerod`) and `monero-wallet-rpc` sidecar. OctoBot receives `MONERO_WALLET_RPC_URL=http://monero-wallet-rpc:18083/json_rpc`.
+
+| Variable | Default | Description |
+|---|---|---|
+| `monero_network` | `mainnet` | `mainnet` or `stagenet` |
+| `monero_remote_daemon` | `""` | If set, skip local monerod and connect wallet-rpc to this remote daemon address |
+| `monerod_mem_limit` | `4g` | Memory limit for the Monero daemon |
+| `monero_wallet_rpc_mem_limit` | `512m` | Memory limit for wallet-rpc |
+
+> **Note:** Initial blockchain sync can take several days and requires significant disk space (~180 GB for mainnet). Set `monero_remote_daemon` to a trusted remote node to skip running a local daemon.
+
+#### Bitcoin (`enable_bitcoin_wallet: true`)
+
+Deploys Bitcoin Core (`bitcoind`) with wallet and RPC support. OctoBot receives `BITCOIN_RPC_URL`, `BITCOIN_RPC_USER`, and `BITCOIN_RPC_PASSWORD`.
+
+| Variable | Default | Description |
+|---|---|---|
+| `bitcoin_network` | `mainnet` | `mainnet` or `testnet` |
+| `bitcoin_rpc_user` | `octobot` | RPC authentication username |
+| `bitcoin_rpc_password` | `""` | RPC authentication password (secret, pass via `--extra-vars`) |
+| `bitcoin_prune` | `550` | Blockchain pruning target in MiB (`0` for full node) |
+| `bitcoind_mem_limit` | `4g` | Memory limit |
+
+> **Note:** With default pruning (`550` MiB), disk usage stays under ~1 GB. Set `bitcoin_prune: 0` for a full archival node (~600 GB).
+
+#### Ethereum (`enable_eth_wallet: true`)
+
+Deploys Geth (go-ethereum) using the official `ethereum/client-go` image. OctoBot receives `ETH_RPC_HTTP_URL=http://geth:8545` and `ETH_RPC_WS_URL=ws://geth:8546`.
+
+| Variable | Default | Description |
+|---|---|---|
+| `eth_network` | `mainnet` | `mainnet`, `sepolia`, or `holesky` |
+| `eth_syncmode` | `snap` | Sync mode: `snap`, `full`, or `light` |
+| `geth_image` | `docker.io/ethereum/client-go:stable` | Geth Docker image |
+| `geth_mem_limit` | `4g` | Memory limit |
+
+> **Note:** Mainnet snap sync requires ~500 GB of disk space. Use a testnet (`sepolia`) for development.
 
 ### Custom Tentacles
 

--- a/infra/node/ansible/inventories/group_vars/all/vars.yml
+++ b/infra/node/ansible/inventories/group_vars/all/vars.yml
@@ -6,6 +6,9 @@
 #   enable_nginx: true
 #   enable_tor: true
 #   enable_hardening: true
+#   enable_monero_wallet: true
+#   enable_bitcoin_wallet: true
+#   enable_eth_wallet: true
 #   secret_key: "your-secret-key"
 #   admin_username: "admin@yourdomain.com"
 #   admin_password: "your-password"

--- a/infra/node/ansible/roles/octobot/defaults/main.yml
+++ b/infra/node/ansible/roles/octobot/defaults/main.yml
@@ -4,6 +4,7 @@ octobot_image: "docker.io/drakkarsoftware/octobot"
 octobot_image_tag: "stable"
 nginx_image: "docker.io/nginx:1-alpine"
 postgres_image: "docker.io/postgres:16-alpine"
+geth_image: "docker.io/ethereum/client-go:stable"
 
 # Deployment
 stack_deploy_dir: "/opt/octobot-node"
@@ -14,10 +15,17 @@ nginx_port: 80
 nginx_ssl_port: 443
 nginx_mem_limit: "256m"
 tor_mem_limit: "256m"
+monerod_mem_limit: "4g"
+monero_wallet_rpc_mem_limit: "512m"
+bitcoind_mem_limit: "4g"
+geth_mem_limit: "4g"
 
 # Feature flags
 enable_hardening: false
 enable_tor: false
+enable_monero_wallet: false
+enable_bitcoin_wallet: false
+enable_eth_wallet: false
 enable_replica_mode: false
 enable_nginx: false
 expose_web_ui: false
@@ -46,6 +54,18 @@ tasks_inputs_rsa_public_key: ""
 tasks_inputs_ecdsa_private_key: ""
 tasks_outputs_rsa_private_key: ""
 tasks_outputs_ecdsa_public_key: ""
+
+# Wallet configuration
+monero_network: "mainnet"          # mainnet or stagenet
+monero_remote_daemon: ""           # if set, skip local monerod and connect wallet-rpc to this address
+
+bitcoin_network: "mainnet"         # mainnet or testnet
+bitcoin_rpc_user: "octobot"
+bitcoin_rpc_password: ""
+bitcoin_prune: 550                 # prune target in MiB (0 for full node)
+
+eth_network: "mainnet"             # mainnet, sepolia, holesky
+eth_syncmode: "snap"               # snap, full, or light
 
 # Firewall (geerlingguy.firewall)
 firewall_allowed_tcp_ports:

--- a/infra/node/ansible/roles/octobot/files/bitcoin/Dockerfile
+++ b/infra/node/ansible/roles/octobot/files/bitcoin/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:3.21@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709
+
+ARG BITCOIN_VERSION=28.1
+ARG BITCOIN_HASH=7fe294b02b25e09c4f2516c8cc3fa57a6407945c86e01a9e3744d4760a6839a1
+
+RUN apk add --no-cache wget ca-certificates && \
+    adduser -D -h /home/bitcoin bitcoin && \
+    wget -qO /tmp/bitcoin.tar.gz \
+      "https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-x86_64-linux-gnu.tar.gz" && \
+    echo "${BITCOIN_HASH}  /tmp/bitcoin.tar.gz" | sha256sum -c && \
+    tar xzf /tmp/bitcoin.tar.gz -C /tmp && \
+    cp /tmp/bitcoin-${BITCOIN_VERSION}/bin/bitcoind /usr/local/bin/ && \
+    cp /tmp/bitcoin-${BITCOIN_VERSION}/bin/bitcoin-cli /usr/local/bin/ && \
+    rm -rf /tmp/bitcoin* && \
+    apk del wget
+
+VOLUME ["/home/bitcoin/.bitcoin"]
+EXPOSE 8332 8333
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD bitcoin-cli -rpcconnect=127.0.0.1 getblockchaininfo || exit 1
+
+USER bitcoin
+
+ENTRYPOINT ["bitcoind"]

--- a/infra/node/ansible/roles/octobot/files/monero/Dockerfile.monerod
+++ b/infra/node/ansible/roles/octobot/files/monero/Dockerfile.monerod
@@ -1,0 +1,25 @@
+FROM alpine:3.21@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709
+
+ARG MONERO_VERSION=0.18.3.4
+ARG MONERO_HASH=1cc1b8baee6a5705e2f5f7a1e74de3c0e8e0a35b7e66a5e75fddea0e4e01243e
+
+RUN apk add --no-cache wget ca-certificates && \
+    adduser -D -h /home/monero monero && \
+    wget -qO /tmp/monero.tar.bz2 \
+      "https://downloads.getmonero.org/cli/monero-linux-x64-v${MONERO_VERSION}.tar.bz2" && \
+    echo "${MONERO_HASH}  /tmp/monero.tar.bz2" | sha256sum -c && \
+    tar xjf /tmp/monero.tar.bz2 -C /tmp && \
+    cp /tmp/monero-x86_64-linux-gnu-v${MONERO_VERSION}/monerod /usr/local/bin/ && \
+    rm -rf /tmp/monero* && \
+    apk del wget
+
+VOLUME ["/home/monero/.bitmonero"]
+EXPOSE 18081
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+    CMD wget -qO- http://127.0.0.1:18081/get_info || exit 1
+
+USER monero
+
+ENTRYPOINT ["monerod"]
+CMD ["--non-interactive", "--restricted-rpc", "--rpc-bind-ip=0.0.0.0", "--rpc-bind-port=18081", "--confirm-external-bind"]

--- a/infra/node/ansible/roles/octobot/files/monero/Dockerfile.wallet-rpc
+++ b/infra/node/ansible/roles/octobot/files/monero/Dockerfile.wallet-rpc
@@ -1,0 +1,27 @@
+FROM alpine:3.21@sha256:c3f8e73fdb79deaebaa2037150150191b9dcbfba68b4a46d70103204c53f4709
+
+ARG MONERO_VERSION=0.18.3.4
+ARG MONERO_HASH=1cc1b8baee6a5705e2f5f7a1e74de3c0e8e0a35b7e66a5e75fddea0e4e01243e
+
+RUN apk add --no-cache wget curl ca-certificates && \
+    adduser -D -h /home/monero monero && \
+    mkdir -p /home/monero/wallets && \
+    chown monero:monero /home/monero/wallets && \
+    wget -qO /tmp/monero.tar.bz2 \
+      "https://downloads.getmonero.org/cli/monero-linux-x64-v${MONERO_VERSION}.tar.bz2" && \
+    echo "${MONERO_HASH}  /tmp/monero.tar.bz2" | sha256sum -c && \
+    tar xjf /tmp/monero.tar.bz2 -C /tmp && \
+    cp /tmp/monero-x86_64-linux-gnu-v${MONERO_VERSION}/monero-wallet-rpc /usr/local/bin/ && \
+    rm -rf /tmp/monero* && \
+    apk del wget
+
+VOLUME ["/home/monero/wallets"]
+EXPOSE 18083
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD curl -sf -X POST http://127.0.0.1:18083/json_rpc \
+        -d '{"jsonrpc":"2.0","id":"0","method":"get_version"}' || exit 1
+
+USER monero
+
+ENTRYPOINT ["monero-wallet-rpc"]

--- a/infra/node/ansible/roles/octobot/handlers/main.yml
+++ b/infra/node/ansible/roles/octobot/handlers/main.yml
@@ -18,3 +18,18 @@
   ansible.builtin.command:
     cmd: docker compose restart tor
     chdir: "{{ stack_deploy_dir }}"
+
+- name: restart monero
+  ansible.builtin.command:
+    cmd: docker compose restart monerod monero-wallet-rpc
+    chdir: "{{ stack_deploy_dir }}"
+
+- name: restart bitcoin
+  ansible.builtin.command:
+    cmd: docker compose restart bitcoin
+    chdir: "{{ stack_deploy_dir }}"
+
+- name: restart geth
+  ansible.builtin.command:
+    cmd: docker compose restart geth
+    chdir: "{{ stack_deploy_dir }}"

--- a/infra/node/ansible/roles/octobot/tasks/main.yml
+++ b/infra/node/ansible/roles/octobot/tasks/main.yml
@@ -39,6 +39,26 @@
   notify: restart tor
   when: enable_tor | default(false) | bool
 
+- name: Copy Monero Dockerfiles
+  ansible.builtin.copy:
+    src: monero/
+    dest: "{{ stack_deploy_dir }}/monero/"
+    owner: deploy
+    group: deploy
+    mode: "0644"
+  notify: restart monero
+  when: enable_monero_wallet | default(false) | bool
+
+- name: Copy Bitcoin Dockerfile
+  ansible.builtin.copy:
+    src: bitcoin/
+    dest: "{{ stack_deploy_dir }}/bitcoin/"
+    owner: deploy
+    group: deploy
+    mode: "0644"
+  notify: restart bitcoin
+  when: enable_bitcoin_wallet | default(false) | bool
+
 - name: Generate self-signed TLS certificate
   ansible.builtin.command:
     cmd: >-

--- a/infra/node/ansible/roles/octobot/templates/docker-compose.yml.j2
+++ b/infra/node/ansible/roles/octobot/templates/docker-compose.yml.j2
@@ -39,9 +39,16 @@ services:
       timeout: 5s
       retries: 5
       start_period: 60s
-{% if enable_tor | default(false) | bool %}
+{% set _deps = [] %}
+{% if enable_tor | default(false) | bool %}{% if _deps.append('tor') %}{% endif %}{% endif %}
+{% if enable_monero_wallet | default(false) | bool %}{% if _deps.append('monero-wallet-rpc') %}{% endif %}{% endif %}
+{% if enable_bitcoin_wallet | default(false) | bool %}{% if _deps.append('bitcoin') %}{% endif %}{% endif %}
+{% if enable_eth_wallet | default(false) | bool %}{% if _deps.append('geth') %}{% endif %}{% endif %}
+{% if _deps %}
     depends_on:
-      - tor
+{% for dep in _deps %}
+      - {{ dep }}
+{% endfor %}
 {% endif %}
     networks:
       - frontend
@@ -50,6 +57,15 @@ services:
 {% endif %}
 {% if enable_tor | default(false) | bool %}
       - tor_net
+{% endif %}
+{% if enable_monero_wallet | default(false) | bool %}
+      - monero_net
+{% endif %}
+{% if enable_bitcoin_wallet | default(false) | bool %}
+      - bitcoin_net
+{% endif %}
+{% if enable_eth_wallet | default(false) | bool %}
+      - eth_net
 {% endif %}
 
 {% if enable_nginx | default(false) | bool %}
@@ -98,6 +114,153 @@ services:
       - tor_net
 {% endif %}
 
+{% if enable_monero_wallet | default(false) | bool %}
+{% if monero_remote_daemon | default('') | length == 0 %}
+  monerod:
+    build:
+      context: ./monero
+      dockerfile: Dockerfile.monerod
+    restart: always
+    mem_limit: {{ monerod_mem_limit }}
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    volumes:
+      - monerod_data:/home/monero/.bitmonero
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:18081/get_info"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s
+    command:
+      - --non-interactive
+      - --restricted-rpc
+      - --rpc-bind-ip=0.0.0.0
+      - --rpc-bind-port=18081
+      - --confirm-external-bind
+{% if monero_network == 'stagenet' %}
+      - --stagenet
+{% endif %}
+    networks:
+      - monero_net
+{% endif %}
+
+  monero-wallet-rpc:
+    build:
+      context: ./monero
+      dockerfile: Dockerfile.wallet-rpc
+    restart: always
+    mem_limit: {{ monero_wallet_rpc_mem_limit }}
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    volumes:
+      - monero_wallet_data:/home/monero/wallets
+{% if monero_remote_daemon | default('') | length > 0 %}
+    command:
+      - --daemon-address={{ monero_remote_daemon }}
+      - --rpc-bind-port=18083
+      - --rpc-bind-ip=0.0.0.0
+      - --disable-rpc-login
+      - --wallet-dir=/home/monero/wallets
+{% if monero_network == 'stagenet' %}
+      - --stagenet
+{% endif %}
+{% else %}
+    depends_on:
+      monerod:
+        condition: service_healthy
+    command:
+      - --daemon-address=monerod:18081
+      - --rpc-bind-port=18083
+      - --rpc-bind-ip=0.0.0.0
+      - --disable-rpc-login
+      - --wallet-dir=/home/monero/wallets
+{% if monero_network == 'stagenet' %}
+      - --stagenet
+{% endif %}
+{% endif %}
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "-X", "POST", "http://127.0.0.1:18083/json_rpc", "-d", "{\"jsonrpc\":\"2.0\",\"id\":\"0\",\"method\":\"get_version\"}"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    networks:
+      - monero_net
+{% endif %}
+
+{% if enable_bitcoin_wallet | default(false) | bool %}
+  bitcoin:
+    build:
+      context: ./bitcoin
+    restart: always
+    mem_limit: {{ bitcoind_mem_limit }}
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    volumes:
+      - bitcoind_data:/home/bitcoin/.bitcoin
+    command:
+      - -server=1
+      - -rpcuser={{ bitcoin_rpc_user }}
+      - -rpcpassword={{ bitcoin_rpc_password }}
+      - -rpcallowip=0.0.0.0/0
+      - -rpcbind=0.0.0.0:8332
+{% if bitcoin_prune | int > 0 %}
+      - -prune={{ bitcoin_prune }}
+{% endif %}
+{% if bitcoin_network == 'testnet' %}
+      - -testnet=1
+{% endif %}
+    healthcheck:
+      test: ["CMD", "bitcoin-cli", "-rpcuser={{ bitcoin_rpc_user }}", "-rpcpassword={{ bitcoin_rpc_password }}", "getblockchaininfo"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s
+    networks:
+      - bitcoin_net
+{% endif %}
+
+{% if enable_eth_wallet | default(false) | bool %}
+  geth:
+    image: {{ geth_image }}
+    restart: always
+    mem_limit: {{ geth_mem_limit }}
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    volumes:
+      - geth_data:/home/geth/.ethereum
+    command:
+      - --http
+      - --http.addr=0.0.0.0
+      - --http.port=8545
+      - --http.api=eth,net,web3,personal
+      - --ws
+      - --ws.addr=0.0.0.0
+      - --ws.port=8546
+      - --ws.api=eth,net,web3,personal
+      - --syncmode={{ eth_syncmode }}
+{% if eth_network != 'mainnet' %}
+      - --{{ eth_network }}
+{% endif %}
+    healthcheck:
+      test: ["CMD", "geth", "attach", "--exec", "eth.syncing", "http://127.0.0.1:8545"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 120s
+    networks:
+      - eth_net
+{% endif %}
+
 {% if enable_replica_mode | default(false) | bool and is_master | default(false) | bool %}
   postgres:
     image: {{ postgres_image }}
@@ -131,6 +294,18 @@ volumes:
 {% if enable_replica_mode | default(false) | bool and is_master | default(false) | bool %}
   postgres_data:
 {% endif %}
+{% if enable_monero_wallet | default(false) | bool %}
+{% if monero_remote_daemon | default('') | length == 0 %}
+  monerod_data:
+{% endif %}
+  monero_wallet_data:
+{% endif %}
+{% if enable_bitcoin_wallet | default(false) | bool %}
+  bitcoind_data:
+{% endif %}
+{% if enable_eth_wallet | default(false) | bool %}
+  geth_data:
+{% endif %}
 
 networks:
   frontend:
@@ -139,4 +314,13 @@ networks:
 {% endif %}
 {% if enable_tor | default(false) | bool %}
   tor_net:
+{% endif %}
+{% if enable_monero_wallet | default(false) | bool %}
+  monero_net:
+{% endif %}
+{% if enable_bitcoin_wallet | default(false) | bool %}
+  bitcoin_net:
+{% endif %}
+{% if enable_eth_wallet | default(false) | bool %}
+  eth_net:
 {% endif %}

--- a/infra/node/ansible/roles/octobot/templates/env.j2
+++ b/infra/node/ansible/roles/octobot/templates/env.j2
@@ -28,6 +28,24 @@ EXCHANGE_SOCKS_PROXY_AUTHENTICATED_URL=socks5h://tor:9050
 USE_AUTHENTICATED_EXCHANGE_REQUESTS_ONLY_PROXY=False
 {% endif %}
 
+{% if enable_monero_wallet | default(false) | bool %}
+# Monero wallet RPC
+MONERO_WALLET_RPC_URL=http://monero-wallet-rpc:18083/json_rpc
+{% endif %}
+
+{% if enable_bitcoin_wallet | default(false) | bool %}
+# Bitcoin Core RPC
+BITCOIN_RPC_URL=http://bitcoin:8332
+BITCOIN_RPC_USER={{ bitcoin_rpc_user }}
+BITCOIN_RPC_PASSWORD={{ bitcoin_rpc_password }}
+{% endif %}
+
+{% if enable_eth_wallet | default(false) | bool %}
+# Ethereum (Geth) RPC
+ETH_RPC_HTTP_URL=http://geth:8545
+ETH_RPC_WS_URL=ws://geth:8546
+{% endif %}
+
 # Tentacles
 {% if additional_tentacles_package_url | default('') | length > 0 %}
 ADDITIONAL_TENTACLES_PACKAGE_URL={{ additional_tentacles_package_url }}


### PR DESCRIPTION
Add complete Ansible-based infrastructure for deploying OctoBot Node
instances with zero-downtime rolling updates.

Stack per node: OctoBot Node + optional Nginx (reverse proxy) + optional
Tor (SOCKS5 proxy) + optional PostgreSQL (on master).

Features:
- Configurable OS/SSH hardening via devsec.hardening
- Custom Tor SOCKS5 proxy Dockerfile (Alpine-based, pinned digest)
- Single node (SQLite) or replica mode (PostgreSQL on master)
- Nginx reverse proxy with TLS, security headers, CSP, rate limiting
- Custom tentacles via URL (ADDITIONAL_TENTACLES_PACKAGE_URL) or ZIP
- New INSTALL_DEFAULT_TENTACLES env var to skip default tentacles
- Web UI exposure gated behind expose_web_ui flag (off by default)
- Telemetry disable support
- Pre-flight inventory validation (max 1 master, topology checks)
- Per-environment overrides with DRY role defaults
- Container hardening: cap_drop ALL, no-new-privileges on all services