### PR TITLE
Replace filelock with threading.Lock in wallet storage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,6 @@ Re-export from the package `__init__.py`. Use typed catches everywhere — never
 ### TypedDicts for structured dicts
 When a dict has a fixed schema (e.g. wallet info returned to callers), define a `typing.TypedDict`. Place it in the module that owns the data, before the class that produces it.
 
-### File locking
-Use the `filelock` library (cross-platform, POSIX + Windows) instead of `fcntl`/`msvcrt` branching.
-
 ### Import priority in tentacle files
 Prefer the installed `tentacles.Services.Interfaces.*` path first; fall back to bare direct imports (build-time fallback). Pattern:
 ```python

--- a/octobot/community/wallet_backend/wallet_storage.py
+++ b/octobot/community/wallet_backend/wallet_storage.py
@@ -19,9 +19,9 @@ import json
 import os
 import pathlib
 import secrets
+import threading
 import typing
 
-import filelock
 import octobot_commons.cryptography.encryption as commons_encryption
 
 import octobot.constants as constants
@@ -121,15 +121,14 @@ class ConfigJsonWalletStorage(WalletStorage):
 class DedicatedFileWalletStorage(WalletStorage):
     """Stores wallets in a standalone JSON file, separate from config.json.
 
-    Writes are atomic (write to .tmp then rename). Cross-platform file locking
-    is provided by the filelock library (fcntl on POSIX, msvcrt on Windows).
-    The threading.Lock in WalletBackend already prevents concurrent in-process
-    calls, so filelock provides defence-in-depth for multi-process scenarios.
+    Writes are atomic (write to .tmp then rename). Concurrent in-process saves
+    are serialized by a threading.Lock, matching the model used by
+    WalletBackend: only the single API process mutates the wallet list.
     """
 
     def __init__(self, file_path: str):
         self._path = pathlib.Path(file_path)
-        self._lock = filelock.FileLock(str(self._path) + ".lock")
+        self._lock = threading.Lock()
 
     def load(self) -> list:
         if not self._path.exists():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 ## Others
-filelock  # cross-platform file locking (POSIX + Windows) used by DedicatedFileWalletStorage
 requests==2.32.5
 urllib3 # required by requests, used in imports: make sure it's always available
 packaging==26.0


### PR DESCRIPTION
Thank you for sending your pull request. 
But first, have you included unit tests, and is your code PEP8 conformant? [More details](https://github.com/Drakkar-Software/OctoBot/blob/dev/CONTRIBUTING.md)

## Summary
Replace cross-process file locking with in-process threading lock in wallet storage, simplifying the implementation based on the single-process API model.

## Changelog

  - Replace `filelock.FileLock` with `threading.Lock` in `DedicatedFileWalletStorage`
  - Remove `filelock` dependency from requirements.txt
  - Update documentation to reflect threading-based synchronization model
  - Remove unnecessary `filelock` import

## What's new?

The wallet storage implementation previously used the `filelock` library to provide cross-platform file locking for multi-process scenarios. However, the OctoBot architecture uses a single API process that mutates the wallet list, making cross-process locking unnecessary.

This change simplifies the implementation by:
- Replacing the file-based lock with a `threading.Lock`, which is sufficient for serializing concurrent in-process saves
- Removing the external `filelock` dependency
- Clarifying the concurrency model in the class docstring to document that only the single API process mutates wallets

The atomic write behavior (write to `.tmp` then rename) is preserved, and the threading lock ensures that concurrent in-process save operations are properly serialized, matching the synchronization model already used by `WalletBackend`.

https://claude.ai/code/session_01WbxpzK9cUqnyUoKJCx19L8