### PR TITLE
fix(sync): raise on unlisted wallet instead of returning empty roles

### DIFF
--- a/packages/sync/octobot_sync/sync/role_resolver.py
+++ b/packages/sync/octobot_sync/sync/role_resolver.py
@@ -77,7 +77,7 @@ def create_role_resolver(
             raise ValueError("Replay")
 
         if is_allowed is not None and not is_allowed(pubkey.lower()):
-            return AuthResult(identity=pubkey, roles=[])
+            raise ValueError("Unauthorized wallet")
 
         # pubkey (client-supplied) not recovered (checksummed) — storage paths key on identity.
         return AuthResult(identity=pubkey, roles=["user"])

--- a/packages/sync/tests/test_role_resolver.py
+++ b/packages/sync/tests/test_role_resolver.py
@@ -144,10 +144,8 @@ async def test_role_resolver_allowlist_denies_unlisted_wallet(nonce):
     with patch("web3.Account.recover_message", return_value=PUBKEY):
         resolver = sync.create_role_resolver(nonce, is_allowed=lambda addr: False)
         req = _make_request("GET", "/v1/test", "", _make_headers(PUBKEY, canonical, "sig", ts, nonce_val))
-        result = await resolver(req)
-
-    assert result.identity == PUBKEY
-    assert result.roles == []
+        with pytest.raises(ValueError, match="Unauthorized wallet"):
+            await resolver(req)
 
 
 async def test_role_resolver_allowlist_none_allows_all(nonce):


### PR DESCRIPTION
## Summary

- Hardens the `is_allowed` deny path in `octobot_sync.sync.role_resolver`: unlisted wallets now raise `ValueError("Unauthorized wallet")` instead of returning `AuthResult(roles=[])`.
- The raise is caught by `starfish_server._check_auth` and returned as **HTTP 401**, consistent with all other auth failures (missing headers, invalid signature, replay, expired timestamp).
- Previously, the soft-deny relied on per-route role gates to produce HTTP 403 — future routes with permissive role configs could have silently let unlisted wallets through.

## Test plan

- [x] `test_role_resolver_allowlist_denies_unlisted_wallet` updated to assert `pytest.raises(ValueError, match="Unauthorized wallet")` — TDD red → green verified locally
- [x] All 11 `test_role_resolver_*` cases pass (`pytest packages/sync/tests/test_role_resolver.py`)
- [x] No production wiring changes — `node_api.py:153-156` keeps the same `is_allowed` lambda

🤖 Generated with [Claude Code](https://claude.com/claude-code)