### PR TITLE
feat(node-web): glass/frost header — transparent over background halo

### DIFF
--- a/packages/tentacles/Services/Interfaces/node_web_interface/src/components/Common/AppHeader.tsx
+++ b/packages/tentacles/Services/Interfaces/node_web_interface/src/components/Common/AppHeader.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button"
 
 export function AppHeader() {
   return (
-    <header className="sticky top-0 z-30 border-b border-rule bg-deep-blue-dark/80 backdrop-blur-xl">
+    <header className="sticky top-0 z-30 border-b border-rule-soft bg-deep-blue/20 backdrop-blur-xl">
       <div className="mx-auto flex max-w-7xl items-center gap-4 px-6 py-4">
         <Logo variant="full" />
         <div className="ml-auto flex items-center gap-3">

--- a/packages/tentacles/Services/Interfaces/node_web_interface/src/index.css
+++ b/packages/tentacles/Services/Interfaces/node_web_interface/src/index.css
@@ -181,7 +181,8 @@
   body {
     font-family: var(--font-sans);
     color-scheme: dark;
-    @apply bg-background text-foreground;
+    background-color: var(--deep-blue);
+    @apply text-foreground;
   }
   button,
   [role="button"] {

--- a/packages/tentacles/Services/Interfaces/node_web_interface/src/routes/_layout.tsx
+++ b/packages/tentacles/Services/Interfaces/node_web_interface/src/routes/_layout.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute("/_layout")({
 
 function Layout() {
   return (
-    <div className="min-h-screen text-foreground">
+    <div className="min-h-screen bg-halo text-foreground">
       <AppHeader />
       <main className="px-6 py-8">
         <div className="mx-auto max-w-7xl">

--- a/packages/tentacles/Services/Interfaces/node_web_interface/src/routes/_layout.tsx
+++ b/packages/tentacles/Services/Interfaces/node_web_interface/src/routes/_layout.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute("/_layout")({
 
 function Layout() {
   return (
-    <div className="min-h-screen bg-halo text-foreground">
+    <div className="min-h-screen bg-halo bg-fixed text-foreground">
       <AppHeader />
       <main className="px-6 py-8">
         <div className="mx-auto max-w-7xl">


### PR DESCRIPTION
## Summary
- Reduce header background from `bg-deep-blue-dark/80` to `bg-deep-blue/20` so the halo radial gradients show through instead of being masked
- Soften header border from `border-rule` to `border-rule-soft` to match the glass aesthetic
- Apply `bg-halo` on the layout root so the gradient is actually rendered
- Body falls back to solid `deep-blue` only; halo gradient lives on the layout container

## Test plan
- [ ] Navigate to the app — halo gradient visible through the header
- [ ] Scroll down — sticky header stays transparent without cutting the halo
- [ ] Other pages (settings, login, setup) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)