### PR TITLE
[Node] remove Basic Auth challenge on /me and /login/test, fix wallet hover style

### DIFF
--- a/packages/tentacles/Services/Interfaces/node_api_interface/api/deps.py
+++ b/packages/tentacles/Services/Interfaces/node_api_interface/api/deps.py
@@ -84,6 +84,20 @@ def get_current_user(
 CurrentUser = typing.Annotated[octobot_node.models.User, Depends(get_current_user)]
 
 
+def get_optional_current_user(
+    credentials: typing.Annotated[typing.Optional[HTTPBasicCredentials], Depends(security_basic)],
+) -> typing.Optional[octobot_node.models.User]:
+    if credentials is None or not credentials.username or not credentials.password:
+        return None
+    try:
+        return get_current_user(credentials)
+    except HTTPException:
+        return None
+
+
+OptionalCurrentUser = typing.Annotated[typing.Optional[octobot_node.models.User], Depends(get_optional_current_user)]
+
+
 def get_current_active_superuser(current_user: CurrentUser) -> octobot_node.models.User:
     if not current_user.is_superuser:
         raise HTTPException(

--- a/packages/tentacles/Services/Interfaces/node_api_interface/api/routes/login.py
+++ b/packages/tentacles/Services/Interfaces/node_api_interface/api/routes/login.py
@@ -19,14 +19,14 @@ import typing
 from fastapi import APIRouter
 
 try:
-    from api.deps import CurrentUser
+    from api.deps import OptionalCurrentUser
 except ImportError:
-    from tentacles.Services.Interfaces.node_api_interface.api.deps import CurrentUser
+    from tentacles.Services.Interfaces.node_api_interface.api.deps import OptionalCurrentUser  # type: ignore[no-redef]
 import octobot_node.models
 
 router = APIRouter(tags=["login"])
 
 
-@router.get("/login/test", response_model=octobot_node.models.User)
-def test_auth(current_user: CurrentUser) -> typing.Any:
+@router.get("/login/test", response_model=typing.Optional[octobot_node.models.User])
+def test_auth(current_user: OptionalCurrentUser) -> typing.Any:
     return current_user

--- a/packages/tentacles/Services/Interfaces/node_api_interface/api/routes/users.py
+++ b/packages/tentacles/Services/Interfaces/node_api_interface/api/routes/users.py
@@ -22,12 +22,12 @@ import octobot_node.models
 # Prefer the installed tentacles package (production target); fall back to
 # direct imports when running from source (build time, tests).
 try:
-    from tentacles.Services.Interfaces.node_api_interface.api.deps import CurrentUser
+    from tentacles.Services.Interfaces.node_api_interface.api.deps import OptionalCurrentUser
 except ImportError:
-    from api.deps import CurrentUser  # type: ignore[no-redef]
+    from api.deps import OptionalCurrentUser  # type: ignore[no-redef]
 
 router = APIRouter(tags=["users"])
 
-@router.get("/me", response_model=octobot_node.models.User)
-def read_user_me(current_user: CurrentUser) -> typing.Any:
+@router.get("/me", response_model=typing.Optional[octobot_node.models.User])
+def read_user_me(current_user: OptionalCurrentUser) -> typing.Any:
     return current_user

--- a/packages/tentacles/Services/Interfaces/node_web_interface/src/hooks/useAuth.ts
+++ b/packages/tentacles/Services/Interfaces/node_web_interface/src/hooks/useAuth.ts
@@ -38,6 +38,7 @@ const useAuth = () => {
     await savePassword(data.password)
     try {
       const loggedInUser = await LoginService.testAuth()
+      if (!loggedInUser) throw new Error("Authentication failed")
       // Store the real node address returned by the server
       localStorage.setItem("auth_username", loggedInUser.email)
       // Store wallet display name for header/menu

--- a/packages/tentacles/Services/Interfaces/node_web_interface/src/routes/login.tsx
+++ b/packages/tentacles/Services/Interfaces/node_web_interface/src/routes/login.tsx
@@ -130,7 +130,7 @@ function Login() {
                 key={wallet.address}
                 type="button"
                 onClick={() => setSelectedWallet(wallet)}
-                className="flex items-center gap-3 rounded-lg border p-4 text-left transition-colors hover:bg-accent hover:text-accent-foreground"
+                className="flex items-center gap-3 rounded-lg border p-4 text-left transition-colors hover:bg-muted"
               >
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

- `/login/test` and `/me` now use `OptionalCurrentUser`: valid credentials return the user, missing/invalid credentials return `null` — no `WWW-Authenticate: Basic` header is sent, so browsers don't pop up a Basic Auth dialog
- Wallet selection card hover on `/login` switched from `hover:bg-accent hover:text-accent-foreground` to `hover:bg-muted` so nested muted-foreground text doesn't wash out

## Test plan

- [x] Hit `/login/test` without credentials → 200 `null` (no 401 challenge)
- [x] Hit `/login/test` with valid credentials → 200 user object
- [x] Hit `/me` without credentials → 200 `null`
- [x] Hover over wallet cards on `/login` → subtle gray background, text remains readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)