### PR TITLE
[Node] improve node distribution UI

### DIFF
--- a/packages/tentacles/Services/Interfaces/web_interface/controllers/distributions/node/dashboard.py
+++ b/packages/tentacles/Services/Interfaces/web_interface/controllers/distributions/node/dashboard.py
@@ -25,7 +25,13 @@ def register(blueprint):
     @login.login_required_when_activated
     def home():
         if models.accepted_terms():
-            return flask.render_template("distributions/node/dashboard.html")
+            node_local_ip, node_local_port = models.get_node_local_endpoint()
+            return flask.render_template(
+                "distributions/node/dashboard.html",
+                node_web_ui_url=models.get_node_web_ui_url(),
+                node_local_ip=node_local_ip,
+                node_local_port=node_local_port,
+            )
         return flask.redirect(flask.url_for("terms"))
 
     @blueprint.route("/welcome")

--- a/packages/tentacles/Services/Interfaces/web_interface/models/__init__.py
+++ b/packages/tentacles/Services/Interfaces/web_interface/models/__init__.py
@@ -291,6 +291,8 @@ from tentacles.Services.Interfaces.web_interface.models.web_interface_tab import
 from tentacles.Services.Interfaces.web_interface.models.distributions import (
     save_market_making_configuration,
     get_market_making_services,
+    get_node_local_endpoint,
+    get_node_web_ui_url,
 )
 
 
@@ -513,5 +515,7 @@ __all__ = [
     "WebInterfaceTab",
     "save_market_making_configuration",
     "get_market_making_services",
+    "get_node_local_endpoint",
+    "get_node_web_ui_url",
     "get_dsl_keywords_docs",
 ]

--- a/packages/tentacles/Services/Interfaces/web_interface/models/distributions/__init__.py
+++ b/packages/tentacles/Services/Interfaces/web_interface/models/distributions/__init__.py
@@ -15,11 +15,16 @@
 #  License along with this library.
 
 from tentacles.Services.Interfaces.web_interface.models.distributions import market_making
+from tentacles.Services.Interfaces.web_interface.models.distributions import node
 from tentacles.Services.Interfaces.web_interface.models.distributions import prediction_market
 
 from tentacles.Services.Interfaces.web_interface.models.distributions.market_making import (
     save_market_making_configuration,
     get_market_making_services,
+)
+from tentacles.Services.Interfaces.web_interface.models.distributions.node import (
+    get_node_local_endpoint,
+    get_node_web_ui_url,
 )
 from tentacles.Services.Interfaces.web_interface.models.distributions.prediction_market import (
     save_prediction_market_configuration,
@@ -29,6 +34,8 @@ from tentacles.Services.Interfaces.web_interface.models.distributions.prediction
 __all__ = [
     "save_market_making_configuration",
     "get_market_making_services",
+    "get_node_local_endpoint",
+    "get_node_web_ui_url",
     "save_prediction_market_configuration",
     "get_prediction_market_services",
 ]

--- a/packages/tentacles/Services/Interfaces/web_interface/models/distributions/node/__init__.py
+++ b/packages/tentacles/Services/Interfaces/web_interface/models/distributions/node/__init__.py
@@ -13,15 +13,15 @@
 #
 #  You should have received a copy of the GNU Lesser General Public
 #  License along with this library.
-import tentacles.Services.Interfaces.web_interface.controllers.logs
-import tentacles.Services.Interfaces.web_interface.controllers.distributions.node.dashboard
 
+import tentacles.Services.Interfaces.web_interface.models.distributions.node.configuration
 
-def register(blueprint):
-    tentacles.Services.Interfaces.web_interface.controllers.logs.register(blueprint)
-    tentacles.Services.Interfaces.web_interface.controllers.distributions.node.dashboard.register(blueprint)
-
+from tentacles.Services.Interfaces.web_interface.models.distributions.node.configuration import (
+    get_node_local_endpoint,
+    get_node_web_ui_url,
+)
 
 __all__ = [
-    "register",
+    "get_node_local_endpoint",
+    "get_node_web_ui_url",
 ]

--- a/packages/tentacles/Services/Interfaces/web_interface/models/distributions/node/configuration.py
+++ b/packages/tentacles/Services/Interfaces/web_interface/models/distributions/node/configuration.py
@@ -1,0 +1,42 @@
+#  Drakkar-Software OctoBot-Interfaces
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+import os
+import socket
+import typing
+
+import octobot_services.constants as services_constants
+import tentacles.Services.Services_bases as Service_bases
+
+
+def get_node_web_ui_url() -> typing.Optional[str]:
+    node_api_service = Service_bases.NodeApiService.instance()
+    if not Service_bases.NodeApiService.get_is_enabled(node_api_service.config):
+        return None
+    return f"{node_api_service.get_node_api_url().rstrip('/')}/app"
+
+
+def get_node_local_endpoint() -> tuple[str, int]:
+    node_api_service = Service_bases.NodeApiService.instance()
+    port = node_api_service.get_bind_port()
+    bind_address = os.getenv(services_constants.ENV_NODE_API_ADDRESS)
+    if bind_address and bind_address not in ("0.0.0.0", "127.0.0.1"):
+        local_ip = bind_address
+    else:
+        try:
+            local_ip = socket.gethostbyname(socket.gethostname())
+        except OSError:
+            local_ip = "127.0.0.1"
+    return local_ip, port

--- a/packages/tentacles/Services/Interfaces/web_interface/templates/distributions/node/dashboard.html
+++ b/packages/tentacles/Services/Interfaces/web_interface/templates/distributions/node/dashboard.html
@@ -8,8 +8,36 @@
             <h4>OctoBot Node</h4>
         </div>
         <div class="card-body text-center">
-            <p class="lead">Node is running.</p>
-            <i id="navbar-bot-status" class="fa fa-check fa-2x text-success"></i>
+            <p class="lead">OctoBot Node is running.</p>
+
+            <p>
+                In node mode, OctoBot should be configured and used from the
+                <a href="https://ui.octobot.cloud" target="_blank" rel="noopener">OctoBot Cloud UI</a>.
+            </p>
+            <a class="btn btn-primary btn-lg mb-4" href="https://ui.octobot.cloud" target="_blank" rel="noopener">
+                Open OctoBot Cloud UI
+            </a>
+
+            <hr class="my-4">
+
+            <h5>Node connection</h5>
+            <p class="mb-1">Use this local endpoint when registering your node:</p>
+            <p class="font-weight-bold mb-1">IP: <code>{{ node_local_ip }}</code></p>
+            <p class="font-weight-bold">Port: <code>{{ node_local_port }}</code></p>
+            <p class="text-muted small">
+                If your node is reachable from the internet, use your public IP and port instead when registering it in the OctoBot Cloud UI.
+            </p>
+
+            <hr class="my-4">
+
+            <h5>Local Node Admin</h5>
+            {% if node_web_ui_url %}
+            <a class="btn btn-outline-primary btn-lg" href="{{ node_web_ui_url }}" target="_blank" rel="noopener">
+                Open Node Admin
+            </a>
+            {% else %}
+            <p class="text-muted">Enable the Node API service to access the Node UI.</p>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/packages/tentacles/Services/Interfaces/web_interface/templates/distributions/node/navbar.html
+++ b/packages/tentacles/Services/Interfaces/web_interface/templates/distributions/node/navbar.html
@@ -21,7 +21,12 @@
     </div>
     <div class="navbar-collapse collapse w-100 order-3 dual-collapse2">
         <ul class="navbar-nav ml-auto" id="main-nav-right-part">
-            <li class="nav-item mx-1 px-0 my-auto">
+            <li class="nav-item mx-1 px-0 my-auto {% if 'logs' == active_page %} active{% endif %}">
+                <a class="nav-link" href="{{ url_for('logs') }}" aria-label="Logs"><i class="fa fa-bell" data-toggle="tooltip" data-placement="top" title="Event logs">
+                    <span id="errors-count-badge" class="badge badge-warning"></span>
+                </i></a>
+            </li>
+            <li class="nav-item mx-1 px-0 my-auto {% if 'logs' == active_page %} active{% endif %}">
                 <a id="theme-switch" class="nav-link" href="#" aria-label="Switch theme" data-update-url="{{url_for('api.display_config')}}">
                     <i class="{{'fa fa-moon' if get_color_mode() == 'light' else 'fas fa-sun'}}" data-toggle="tooltip" data-placement="top"
                        title="Use {{'dark' if get_color_mode() == 'light' else 'light'}} theme">

--- a/packages/tentacles/Services/Interfaces/web_interface/tests/distributions/test_node.py
+++ b/packages/tentacles/Services/Interfaces/web_interface/tests/distributions/test_node.py
@@ -1,0 +1,50 @@
+#  Drakkar-Software OctoBot-Tentacles
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+
+import pytest
+
+import tentacles.Services.Interfaces.web_interface.tests.distribution_tester as distribution_tester
+import octobot.enums
+
+
+# All test coroutines will be treated as marked.
+pytestmark = pytest.mark.asyncio
+
+
+_COMMUNITY_ACCOUNT_REQUIRED_PATHS = [
+    "/api/tradingview_confirm_email_content",
+]
+
+
+class TestNodeDistributionPlugin(distribution_tester.AbstractDistributionTester):
+    DISTRIBUTION = octobot.enums.OctoBotDistribution.NODE
+    # backlist endpoints expecting additional data
+    URL_BLACK_LIST = [
+        "/tentacle_media", "/export_logs", "/api/first_exchange_details"
+    ]
+    DOTTED_URLS = ["/robots.txt"]
+    VERBOSE = False
+
+    async def test_browse_all_pages_no_required_password(self):
+        await self._inner_test_browse_all_pages_no_required_password(_COMMUNITY_ACCOUNT_REQUIRED_PATHS)
+
+    async def test_browse_all_pages_required_password_without_login(self):
+        await self._inner_test_browse_all_pages_required_password_without_login([])
+
+    async def test_browse_all_pages_required_password_with_login(self):
+        await self.inner_test_browse_all_pages_required_password_with_login(
+            _COMMUNITY_ACCOUNT_REQUIRED_PATHS, []
+        )

--- a/packages/tentacles/Services/Interfaces/web_interface/tests/test_node_configuration_models.py
+++ b/packages/tentacles/Services/Interfaces/web_interface/tests/test_node_configuration_models.py
@@ -1,0 +1,72 @@
+#  Drakkar-Software OctoBot-Tentacles
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+
+import mock
+
+import octobot_services.constants as services_constants
+import tentacles.Services.Interfaces.web_interface.models.distributions.node.configuration as node_configuration_model
+
+
+class TestGetNodeLocalEndpoint:
+    def test_uses_explicit_bind_address_when_not_loopback_or_any(self):
+        node_api_service = mock.Mock()
+        node_api_service.get_bind_port.return_value = 8000
+
+        with mock.patch.object(
+            node_configuration_model.Service_bases.NodeApiService,
+            "instance",
+            mock.Mock(return_value=node_api_service),
+        ), mock.patch.dict("os.environ", {services_constants.ENV_NODE_API_ADDRESS: "192.168.1.42"}, clear=False):
+            local_ip, port = node_configuration_model.get_node_local_endpoint()
+
+        assert local_ip == "192.168.1.42"
+        assert port == 8000
+
+    def test_resolves_hostname_when_bind_address_is_any(self):
+        node_api_service = mock.Mock()
+        node_api_service.get_bind_port.return_value = 9001
+
+        with mock.patch.object(
+            node_configuration_model.Service_bases.NodeApiService,
+            "instance",
+            mock.Mock(return_value=node_api_service),
+        ), mock.patch.dict("os.environ", {services_constants.ENV_NODE_API_ADDRESS: "0.0.0.0"}, clear=False), mock.patch.object(
+            node_configuration_model.socket,
+            "gethostbyname",
+            mock.Mock(return_value="10.0.0.5"),
+        ):
+            local_ip, port = node_configuration_model.get_node_local_endpoint()
+
+        assert local_ip == "10.0.0.5"
+        assert port == 9001
+
+    def test_falls_back_to_loopback_when_hostname_resolution_fails(self):
+        node_api_service = mock.Mock()
+        node_api_service.get_bind_port.return_value = 8000
+
+        with mock.patch.object(
+            node_configuration_model.Service_bases.NodeApiService,
+            "instance",
+            mock.Mock(return_value=node_api_service),
+        ), mock.patch.dict("os.environ", {}, clear=True), mock.patch.object(
+            node_configuration_model.socket,
+            "gethostbyname",
+            mock.Mock(side_effect=OSError("hostname resolution failed")),
+        ):
+            local_ip, port = node_configuration_model.get_node_local_endpoint()
+
+        assert local_ip == "127.0.0.1"
+        assert port == 8000


### PR DESCRIPTION
next (other PR): start in node by default

add more info in /home and display the logs tab for debug (urls to cloud are temporary)
<img width="1919" height="724" alt="image" src="https://github.com/user-attachments/assets/10414439-7884-492d-9ec3-c0217116425f" />
