### PR TITLE
[Interfaces] save fastapi uncatched exceptions in logs

### DIFF
--- a/packages/commons/octobot_commons/logging/__init__.py
+++ b/packages/commons/octobot_commons/logging/__init__.py
@@ -45,6 +45,9 @@ from octobot_commons.logging.context_based_file_handler import (
     add_context_based_file_handler,
     ContextBasedFileHandler,
 )
+from octobot_commons.logging.fastapi_unhandled_exception_handlers import (
+    register_unhandled_exception_handler,
+)
 
 
 __all__ = [
@@ -74,4 +77,5 @@ __all__ = [
     "set_enable_web_interface_logs",
     "add_context_based_file_handler",
     "ContextBasedFileHandler",
+    "register_unhandled_exception_handler",
 ]

--- a/packages/commons/octobot_commons/logging/fastapi_unhandled_exception_handlers.py
+++ b/packages/commons/octobot_commons/logging/fastapi_unhandled_exception_handlers.py
@@ -1,0 +1,60 @@
+#  Drakkar-Software OctoBot-Commons
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+
+import logging as stdlib_logging
+import typing
+
+import octobot_commons.logging.logging_util as logging_util
+
+_fastapi_available = False
+
+try:
+    import starlette.requests
+    import starlette.responses
+    _fastapi_available = True
+except ImportError:
+    pass
+
+if typing.TYPE_CHECKING:
+    from fastapi import FastAPI
+
+
+def register_unhandled_exception_handler(app: "FastAPI", logger_name: str) -> None:
+    """Log unhandled API exceptions to OctoBot logging and return HTTP 500."""
+    if not _fastapi_available:
+        stdlib_logging.getLogger(__name__).warning(
+            "FastAPI is not installed; unhandled exception handler was not registered for %r",
+            logger_name,
+        )
+        return
+
+    logger = logging_util.get_logger(logger_name)
+
+    async def unhandled_exception_handler(
+        request: starlette.requests.Request,
+        exc: Exception,
+    ) -> starlette.responses.JSONResponse:
+        logger.exception(
+            exc,
+            True,
+            f"Unhandled API error: {request.method} {request.url.path}",
+        )
+        return starlette.responses.JSONResponse(
+            status_code=500,
+            content={"detail": "Internal Server Error"},
+        )
+
+    app.add_exception_handler(Exception, unhandled_exception_handler)

--- a/packages/commons/tests/logging/test_fastapi_unhandled_exception_handlers.py
+++ b/packages/commons/tests/logging/test_fastapi_unhandled_exception_handlers.py
@@ -1,0 +1,107 @@
+#  Drakkar-Software OctoBot-Commons
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+
+import mock
+import pydantic
+import pytest
+import fastapi
+from fastapi import HTTPException
+from starlette.testclient import TestClient
+
+import octobot_commons.logging.fastapi_unhandled_exception_handlers as fastapi_unhandled_exception_handlers
+
+
+class _ValidatedBody(pydantic.BaseModel):
+    name: str
+
+
+@pytest.fixture
+def routes_app():
+    app = fastapi.FastAPI()
+
+    @app.get("/boom")
+    async def boom():
+        raise RuntimeError("boom")
+
+    @app.get("/not-found")
+    async def not_found():
+        raise HTTPException(status_code=404, detail="missing")
+
+    @app.post("/validated")
+    async def validated(body: _ValidatedBody):
+        return body
+
+    return app
+
+
+def _register_handler(app: fastapi.FastAPI) -> None:
+    fastapi_unhandled_exception_handlers.register_unhandled_exception_handler(app, "test-api-logger")
+
+
+class TestRegisterUnhandledExceptionHandler:
+    def test_logs_unhandled_exception(self, routes_app):
+        mock_logger = mock.Mock()
+        with mock.patch(
+            "octobot_commons.logging.fastapi_unhandled_exception_handlers.logging_util.get_logger",
+            return_value=mock_logger,
+        ):
+            _register_handler(routes_app)
+            with TestClient(routes_app, raise_server_exceptions=False) as client:
+                client.get("/boom")
+
+        mock_logger.exception.assert_called_once()
+        call_args = mock_logger.exception.call_args
+        assert call_args[0][0].__class__ is RuntimeError
+        assert "GET /boom" in call_args[0][2]
+
+    def test_returns_500_json(self, routes_app):
+        with mock.patch(
+            "octobot_commons.logging.fastapi_unhandled_exception_handlers.logging_util.get_logger",
+            return_value=mock.Mock(),
+        ):
+            _register_handler(routes_app)
+            with TestClient(routes_app, raise_server_exceptions=False) as client:
+                response = client.get("/boom")
+
+        assert response.status_code == 500
+        assert response.json() == {"detail": "Internal Server Error"}
+
+    def test_http_exception_not_logged(self, routes_app):
+        mock_logger = mock.Mock()
+        with mock.patch(
+            "octobot_commons.logging.fastapi_unhandled_exception_handlers.logging_util.get_logger",
+            return_value=mock_logger,
+        ):
+            _register_handler(routes_app)
+            with TestClient(routes_app, raise_server_exceptions=False) as client:
+                response = client.get("/not-found")
+
+        mock_logger.exception.assert_not_called()
+        assert response.status_code == 404
+        assert response.json() == {"detail": "missing"}
+
+    def test_validation_error_not_logged(self, routes_app):
+        mock_logger = mock.Mock()
+        with mock.patch(
+            "octobot_commons.logging.fastapi_unhandled_exception_handlers.logging_util.get_logger",
+            return_value=mock_logger,
+        ):
+            _register_handler(routes_app)
+            with TestClient(routes_app, raise_server_exceptions=False) as client:
+                response = client.post("/validated", json={})
+
+        mock_logger.exception.assert_not_called()
+        assert response.status_code == 422

--- a/packages/sync/octobot_sync/app.py
+++ b/packages/sync/octobot_sync/app.py
@@ -27,6 +27,7 @@ from starfish_server.auth.revocation_store import create_in_memory_revocation_st
 
 import starfish_identities
 
+import octobot_commons.logging as octobot_commons_logging
 import octobot_sync.constants as constants
 import octobot_sync.sync as sync
 
@@ -107,6 +108,8 @@ def create_app(
         sync_config = sync.load_sync_config(collections_path)
 
     app = FastAPI(title="OctoBot Sync — Signal Sync Server")
+
+    octobot_commons_logging.register_unhandled_exception_handler(app, "OctoBot-Sync")
 
     sync_router = create_sync_router(
         SyncRouterOptions(

--- a/packages/sync/tests/test_exception_handlers.py
+++ b/packages/sync/tests/test_exception_handlers.py
@@ -1,0 +1,57 @@
+#  Drakkar-Software OctoBot-Sync
+#  Copyright (c) Drakkar-Software, All rights reserved.
+#
+#  This library is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU Lesser General Public
+#  License as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  This library is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  Lesser General Public License for more details.
+#
+#  You should have received a copy of the GNU Lesser General Public
+#  License along with this library.
+
+import mock
+import pytest
+import fastapi
+from starlette.testclient import TestClient
+
+import octobot_commons.logging as octobot_commons_logging
+import octobot_sync.app as sync_app
+
+
+class TestSyncAppUnhandledExceptionHandler:
+    async def test_create_app_registers_unhandled_exception_handler(self):
+        store = mock.Mock()
+        wrapped_app = sync_app.create_app(store)
+        inner_app = wrapped_app.app
+        assert Exception in inner_app.exception_handlers
+
+    def test_mounted_sync_unhandled_exception_is_logged(self):
+        inner_app = fastapi.FastAPI()
+
+        @inner_app.get("/boom")
+        async def boom():
+            raise RuntimeError("sync boom")
+
+        parent_app = fastapi.FastAPI()
+        parent_app.mount("/sync", sync_app.SignedPathMiddleware(inner_app))
+
+        mock_logger = mock.Mock()
+        with mock.patch(
+            "octobot_commons.logging.fastapi_unhandled_exception_handlers.logging_util.get_logger",
+            return_value=mock_logger,
+        ):
+            octobot_commons_logging.register_unhandled_exception_handler(inner_app, "OctoBot-Sync")
+            with TestClient(parent_app, raise_server_exceptions=False) as client:
+                response = client.get("/sync/boom")
+
+        assert response.status_code == 500
+        assert response.json() == {"detail": "Internal Server Error"}
+        mock_logger.exception.assert_called_once()
+        log_message = mock_logger.exception.call_args[0][2]
+        assert "GET" in log_message
+        assert "boom" in log_message

--- a/packages/tentacles/Services/Interfaces/node_api_interface/node_api.py
+++ b/packages/tentacles/Services/Interfaces/node_api_interface/node_api.py
@@ -28,6 +28,7 @@ import octobot.community.authentication as community_auth
 import octobot_services.constants as services_constants
 import octobot_services.interfaces as services_interfaces
 import octobot_services.interfaces.util.web as web_util
+import octobot_commons.logging as octobot_commons_logging
 import octobot_node.config as node_config
 import octobot_node.scheduler as scheduler # noqa: F401
 import octobot_sync.server as sync_server
@@ -163,6 +164,8 @@ class NodeApiInterface(services_interfaces.AbstractInterface):
             generate_unique_id_function=custom_generate_unique_id,
             lifespan=lifespan,
         )
+
+        octobot_commons_logging.register_unhandled_exception_handler(app, "node_api_interface")
 
         app.include_router(build_api_router(), prefix="/api/v1")
 

--- a/packages/tentacles/Services/Interfaces/node_api_interface/tests/test_exception_handlers.py
+++ b/packages/tentacles/Services/Interfaces/node_api_interface/tests/test_exception_handlers.py
@@ -1,0 +1,23 @@
+#  This file is part of OctoBot Node (https://github.com/Drakkar-Software/OctoBot-Node)
+#  Copyright (c) 2025 Drakkar-Software, All rights reserved.
+#
+#  OctoBot is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either
+#  version 3.0 of the License, or (at your option) any later version.
+#
+#  OctoBot is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#  General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public
+#  License along with OctoBot. If not, see <https://www.gnu.org/licenses/>.
+
+import tentacles.Services.Interfaces.node_api_interface.node_api as node_api_module
+
+
+class TestNodeApiInterfaceCreateApp:
+    def test_registers_unhandled_exception_handler(self):
+        app = node_api_module.NodeApiInterface.create_app()
+        assert Exception in app.exception_handlers


### PR DESCRIPTION
issue is that currently, when an api ends up raising, only the console gets the error. With this, the error is also saved in logs