### PR TITLE
[Node] allow wallet admin to exec user actions on other wallet's bots

### DIFF
--- a/packages/node/octobot_node/scheduler/scheduler.py
+++ b/packages/node/octobot_node/scheduler/scheduler.py
@@ -300,6 +300,33 @@ class Scheduler:
         latest_workflow = workflows_util.get_latest_child_workflow(matching_workflows)
         return [latest_workflow.workflow_id]
 
+    async def resolve_automation_owner_user_id(
+        self,
+        parent_id: str,
+    ) -> typing.Optional[str]:
+        """
+        Return the Starfish ``user_id`` that owns the active automation for ``parent_id``.
+
+        Unlike :meth:`resolve_active_automation_workflow_ids_for_parent_id`, this lookup is not
+        wallet-scoped so callers can resolve cross-wallet ownership after API-side authorization.
+        """
+        matching_workflows = await self._get_parent_and_children_automation_workflows(
+            None,
+            [parent_id],
+            [
+                dbos.WorkflowStatusString.ENQUEUED,
+                dbos.WorkflowStatusString.PENDING,
+            ],
+            load_output=False,
+        )
+        if not matching_workflows:
+            return None
+        latest_workflow = workflows_util.get_latest_child_workflow(matching_workflows)
+        task = workflows_util.get_automation_input_task(latest_workflow)
+        if task is None:
+            return None
+        return task.user_id
+
     async def resolve_latest_terminal_automation_workflow_for_parent_id(
         self,
         user_id: typing.Optional[str],

--- a/packages/node/tests/scheduler/test_scheduler.py
+++ b/packages/node/tests/scheduler/test_scheduler.py
@@ -1034,6 +1034,44 @@ class TestSchedulerGetUserActionWorkflowIds:
         assert result == ["wf-done"]
 
 
+class TestResolveAutomationOwnerUserId:
+    @pytest.mark.asyncio
+    async def test_returns_owner_user_id_from_latest_active_workflow(self):
+        parent_id = PARENT_ID
+        owner_user_id = "tenant-starfish-id"
+        task = octobot_node.models.Task(
+            id=parent_id,
+            name="tenant-task",
+            content=None,
+            type="execute_actions",
+            user_id=owner_user_id,
+        )
+        older_child = _build_mock_workflow_status_no_output(task, workflow_id=f"{parent_id}_1")
+        older_child.status = dbos.WorkflowStatusString.PENDING.value
+        older_child.updated_at = 10
+        latest_child = _build_mock_workflow_status_no_output(task, workflow_id=f"{parent_id}_2")
+        latest_child.status = dbos.WorkflowStatusString.ENQUEUED.value
+        latest_child.updated_at = 20
+
+        sched, mock_instance = _make_scheduler_with_mock_instance()
+        mock_instance.list_workflows_async = mock.AsyncMock(
+            return_value=[older_child, latest_child],
+        )
+
+        result = await sched.resolve_automation_owner_user_id(parent_id)
+
+        assert result == owner_user_id
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_matching_workflow(self):
+        sched, mock_instance = _make_scheduler_with_mock_instance()
+        mock_instance.list_workflows_async = mock.AsyncMock(return_value=[])
+
+        result = await sched.resolve_automation_owner_user_id("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+        assert result is None
+
+
 class TestSchedulerDeleteWorkflows:
     @pytest.mark.asyncio
     async def test_delegates_to_workflows_retention_helpers(self):

--- a/packages/tentacles/Services/Interfaces/node_api_interface/api/routes/debug.py
+++ b/packages/tentacles/Services/Interfaces/node_api_interface/api/routes/debug.py
@@ -97,6 +97,68 @@ def _resolve_user_id(
     return evm_to_user_id(evm_address)
 
 
+def _extract_automation_parent_id(
+    user_action: protocol_models.UserAction,
+) -> typing.Optional[str]:
+    wrapper = user_action.configuration
+    if wrapper is None or wrapper.actual_instance is None:
+        return None
+    payload = wrapper.actual_instance
+    if isinstance(payload, protocol_models.StopAutomationConfiguration):
+        return payload.id
+    if isinstance(payload, protocol_models.RestartAutomationConfiguration):
+        return payload.id
+    if isinstance(payload, protocol_models.SignalAutomationConfiguration):
+        return payload.automation_id
+    return None
+
+
+async def _resolve_execution_user_id(
+    current_user: octobot_node.models.User,
+    wallet_address: typing.Optional[str],
+    user_action: protocol_models.UserAction,
+) -> str:
+    """Pick the Starfish user_id passed to the scheduler for this user action.
+
+    For stop/signal/restart, the executor resolves the active DBOS workflow using a
+    wallet-scoped lookup. Admins may act on another wallet's automation without passing
+    ``wallet_address``, but only after API-side authorization and owner resolution here.
+    """
+    # Explicit wallet override: admin-gated in _resolve_wallet_address.
+    if wallet_address is not None:
+        return _resolve_user_id(current_user, wallet_address)
+
+    caller_user_id = _resolve_user_id(current_user, None)
+    parent_automation_id = _extract_automation_parent_id(user_action)
+    if parent_automation_id is None:
+        return caller_user_id
+
+    scheduler = octobot_node.scheduler.SCHEDULER
+    # Caller-owned automation: keep the authenticated wallet's user_id.
+    active_workflow_ids = await scheduler.resolve_active_automation_workflow_ids_for_parent_id(
+        caller_user_id,
+        parent_automation_id,
+    )
+    if active_workflow_ids:
+        return caller_user_id
+
+    # Cross-wallet: only superusers may resolve the automation owner without wallet filter.
+    if current_user.is_superuser:
+        owner_user_id = await scheduler.resolve_automation_owner_user_id(parent_automation_id)
+        if owner_user_id is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Automation not found",
+            )
+        return owner_user_id
+
+    # Non-superuser and automation not under caller's wallet.
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="Automation not found",
+    )
+
+
 def _ensure_debug_routes_enabled() -> None:
     if octobot_node.config.settings.is_node_side_encryption_enabled:
         raise HTTPException(
@@ -144,7 +206,7 @@ async def execute_user_action(
     _ensure_debug_routes_enabled()
     _ensure_scheduler_initialized()
     user_action = _parse_user_action_payload(payload)
-    resolved_user_id = _resolve_user_id(current_user, wallet_address)
+    resolved_user_id = await _resolve_execution_user_id(current_user, wallet_address, user_action)
     try:
         await user_actions_protocol.execute_user_action(user_action, resolved_user_id)
     except RuntimeError as error:

--- a/packages/tentacles/Services/Interfaces/node_api_interface/tests/test_routes_debug.py
+++ b/packages/tentacles/Services/Interfaces/node_api_interface/tests/test_routes_debug.py
@@ -15,15 +15,18 @@
 #  License along with OctoBot. If not, see <https://www.gnu.org/licenses/>.
 
 import base64
+import contextlib
 import mock
+import pytest
 
 import octobot_node.config
+import octobot_node.scheduler
 import octobot_protocol.models as protocol_models
 import octobot_sync.constants as sync_constants
 
 from datetime import datetime, timezone
 
-from .conftest import ADMIN_ADDRESS, ADMIN_PASSPHRASE, TENANT_ADDRESS, TENANT_USER_ID
+from .conftest import ADMIN_ADDRESS, ADMIN_PASSPHRASE, ADMIN_USER_ID, TENANT_ADDRESS, TENANT_USER_ID
 
 
 def _sample_debug_state() -> protocol_models.DebugState:
@@ -78,6 +81,62 @@ def _stop_automation_user_action_payload() -> dict:
             "id": "00000000-0000-4000-8000-000000000099",
         },
     }
+
+
+def _restart_automation_user_action_payload() -> dict:
+    return {
+        "id": "ua-restart-api-test",
+        "configuration": {
+            "action_type": "automation_restart",
+            "id": "00000000-0000-4000-8000-000000000099",
+        },
+    }
+
+
+_AUTOMATION_PARENT_ID = "00000000-0000-4000-8000-000000000099"
+
+
+@contextlib.contextmanager
+def _automation_owned_by_caller():
+    with mock.patch.object(
+        octobot_node.scheduler.SCHEDULER,
+        "resolve_active_automation_workflow_ids_for_parent_id",
+        new_callable=mock.AsyncMock,
+        return_value=[f"{_AUTOMATION_PARENT_ID}_1"],
+    ):
+        yield
+
+
+@contextlib.contextmanager
+def _automation_not_owned_by_caller(*, owner_user_id: str):
+    with mock.patch.object(
+        octobot_node.scheduler.SCHEDULER,
+        "resolve_active_automation_workflow_ids_for_parent_id",
+        new_callable=mock.AsyncMock,
+        return_value=[],
+    ), mock.patch.object(
+        octobot_node.scheduler.SCHEDULER,
+        "resolve_automation_owner_user_id",
+        new_callable=mock.AsyncMock,
+        return_value=owner_user_id,
+    ):
+        yield
+
+
+@contextlib.contextmanager
+def _automation_not_found():
+    with mock.patch.object(
+        octobot_node.scheduler.SCHEDULER,
+        "resolve_active_automation_workflow_ids_for_parent_id",
+        new_callable=mock.AsyncMock,
+        return_value=[],
+    ), mock.patch.object(
+        octobot_node.scheduler.SCHEDULER,
+        "resolve_automation_owner_user_id",
+        new_callable=mock.AsyncMock,
+        return_value=None,
+    ):
+        yield
 
 
 def _auth_header(address: str, passphrase: str) -> dict:
@@ -217,10 +276,11 @@ class TestExecuteUserAction:
             new=mock_execute_user_action,
         ):
             with mock.patch("octobot_node.scheduler.is_initialized", return_value=True):
-                response = tenant_client.post(
-                    "/api/v1/debug/",
-                    json=_signal_user_action_payload(),
-                )
+                with _automation_owned_by_caller():
+                    response = tenant_client.post(
+                        "/api/v1/debug/",
+                        json=_signal_user_action_payload(),
+                    )
         assert response.status_code == 204
         assert response.content == b""
         user_action_argument = mock_execute_user_action.await_args[0][0]
@@ -239,10 +299,11 @@ class TestExecuteUserAction:
             new=mock_execute_user_action,
         ):
             with mock.patch("octobot_node.scheduler.is_initialized", return_value=True):
-                response = tenant_client.post(
-                    "/api/v1/debug/",
-                    json=_stop_automation_user_action_payload(),
-                )
+                with _automation_owned_by_caller():
+                    response = tenant_client.post(
+                        "/api/v1/debug/",
+                        json=_stop_automation_user_action_payload(),
+                    )
         assert response.status_code == 204
         user_action_argument = mock_execute_user_action.await_args[0][0]
         configuration = user_action_argument.configuration.actual_instance
@@ -320,3 +381,81 @@ class TestExecuteUserAction:
             response = tenant_client.post("/api/v1/debug/", json=_minimal_user_action_payload())
         assert response.status_code == 404
         assert response.json()["detail"] == "Debug routes are disabled when node-side encryption is enabled"
+
+
+class TestExecuteUserActionCrossWalletAutomation:
+    @pytest.mark.parametrize(
+        "payload_factory",
+        [
+            _stop_automation_user_action_payload,
+            _signal_user_action_payload,
+            _restart_automation_user_action_payload,
+        ],
+    )
+    def test_admin_without_wallet_address_uses_owner_user_id(
+        self,
+        admin_client,
+        mock_auth,
+        payload_factory,
+    ):
+        mock_execute_user_action = mock.AsyncMock(return_value=None)
+        with mock.patch(
+            "octobot_node.protocol.user_actions.execute_user_action",
+            new=mock_execute_user_action,
+        ):
+            with mock.patch("octobot_node.scheduler.is_initialized", return_value=True):
+                with _automation_not_owned_by_caller(owner_user_id=TENANT_USER_ID):
+                    response = admin_client.post(
+                        "/api/v1/debug/",
+                        json=payload_factory(),
+                    )
+        assert response.status_code == 204
+        assert mock_execute_user_action.await_args[0][1] == TENANT_USER_ID
+
+    @pytest.mark.parametrize(
+        "payload_factory",
+        [
+            _stop_automation_user_action_payload,
+            _signal_user_action_payload,
+            _restart_automation_user_action_payload,
+        ],
+    )
+    def test_non_admin_without_wallet_address_returns_404_when_not_owned(
+        self,
+        tenant_client,
+        mock_auth,
+        payload_factory,
+    ):
+        mock_execute_user_action = mock.AsyncMock(return_value=None)
+        with mock.patch(
+            "octobot_node.protocol.user_actions.execute_user_action",
+            new=mock_execute_user_action,
+        ):
+            with mock.patch("octobot_node.scheduler.is_initialized", return_value=True):
+                with _automation_not_found():
+                    response = tenant_client.post(
+                        "/api/v1/debug/",
+                        json=payload_factory(),
+                    )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Automation not found"
+        mock_execute_user_action.assert_not_awaited()
+
+    def test_admin_without_wallet_address_uses_own_user_id_when_automation_is_owned(
+        self,
+        admin_client,
+        mock_auth,
+    ):
+        mock_execute_user_action = mock.AsyncMock(return_value=None)
+        with mock.patch(
+            "octobot_node.protocol.user_actions.execute_user_action",
+            new=mock_execute_user_action,
+        ):
+            with mock.patch("octobot_node.scheduler.is_initialized", return_value=True):
+                with _automation_owned_by_caller():
+                    response = admin_client.post(
+                        "/api/v1/debug/",
+                        json=_stop_automation_user_action_payload(),
+                    )
+        assert response.status_code == 204
+        assert mock_execute_user_action.await_args[0][1] == ADMIN_USER_ID


### PR DESCRIPTION
allows to stop bots/automations started before reseting/wiping the local config.json wallet