### PR TITLE
fix(node-web-interface): use the real published octobot-client

### DIFF
--- a/packages/tentacles/Services/Interfaces/node_web_interface/package-lock.json
+++ b/packages/tentacles/Services/Interfaces/node_web_interface/package-lock.json
@@ -8,7 +8,7 @@
       "name": "octobot-node",
       "version": "0.0.0",
       "dependencies": {
-        "@drakkar.software/octobot-client": "file:../../../../client/octobot_client_ts",
+        "@drakkar.software/octobot-client": "^0.8.0",
         "@drakkar.software/octochat-sdk": "^0.8.1",
         "@drakkar.software/starfish-identities": "3.0.0-alpha.27",
         "@hookform/resolvers": "^5.2.2",
@@ -64,30 +64,6 @@
         "typescript": "^5.9.3",
         "vite": "^8.0.10",
         "vitest": "^4.1.5"
-      }
-    },
-    "../../../../client/octobot_client_ts": {
-      "name": "@drakkar.software/octobot-client",
-      "version": "0.8.0",
-      "license": "LGPL-3.0",
-      "dependencies": {
-        "@drakkar.software/octobot-protocol": "^0.8.0",
-        "@drakkar.software/starfish-client": "3.0.0-alpha.72",
-        "@drakkar.software/starfish-identities": "3.0.0-alpha.72",
-        "@drakkar.software/starfish-keyring": "3.0.0-alpha.72",
-        "@drakkar.software/starfish-protocol": "3.0.0-alpha.72",
-        "@drakkar.software/starfish-replica": "3.0.0-alpha.72",
-        "@drakkar.software/starfish-spaces": "3.0.0-alpha.72",
-        "@noble/curves": "2.2.0",
-        "@noble/hashes": "2.2.0"
-      },
-      "devDependencies": {
-        "@types/node": "^20.11.0",
-        "typescript": "~5.9.2",
-        "vitest": "^2.1.9"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -556,8 +532,166 @@
       }
     },
     "node_modules/@drakkar.software/octobot-client": {
-      "resolved": "../../../../client/octobot_client_ts",
-      "link": true
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@drakkar.software/octobot-client/-/octobot-client-0.8.0.tgz",
+      "integrity": "sha512-xTb4IDy7heR2juHlx2N8lRZ6L6RrihyFYt3DJhR/GmE62zW2vc73n+rgq3VkT9nwiuhYA7vtnnD44s11gPV1fQ==",
+      "license": "LGPL-3.0",
+      "dependencies": {
+        "@drakkar.software/octobot-protocol": "^0.8.0",
+        "@drakkar.software/starfish-client": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-identities": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-keyring": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-protocol": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-replica": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-spaces": "3.0.0-alpha.72",
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@drakkar.software/octobot-client/node_modules/@drakkar.software/starfish-client": {
+      "version": "3.0.0-alpha.72",
+      "resolved": "https://registry.npmjs.org/@drakkar.software/starfish-client/-/starfish-client-3.0.0-alpha.72.tgz",
+      "integrity": "sha512-JNL6cE252uULa1jtyk4YczvUkOFlDkQXamBdCRb9MNl2uEfVkEmndPUBe1BludXQoZR7UWTP48f/br5lTPPTjg==",
+      "dependencies": {
+        "@drakkar.software/starfish-protocol": "3.0.0-alpha.72"
+      },
+      "peerDependencies": {
+        "@legendapp/state": ">=2.0.0",
+        "immer": ">=9.0.0",
+        "react": ">=18.0.0",
+        "zustand": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@legendapp/state": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "zustand": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@drakkar.software/octobot-client/node_modules/@drakkar.software/starfish-identities": {
+      "version": "3.0.0-alpha.72",
+      "resolved": "https://registry.npmjs.org/@drakkar.software/starfish-identities/-/starfish-identities-3.0.0-alpha.72.tgz",
+      "integrity": "sha512-WwRC8mjqqTsJEWk8j/kKdH0uV65M9DZxmkOnMgLu28wuwm5R64gG7YluYNOaj7+2HmkBRgnM4wWEg1N3x66ycw==",
+      "dependencies": {
+        "@drakkar.software/starfish-client": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-keyring": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-protocol": "3.0.0-alpha.72",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.0.0",
+        "hash-wasm": "^4.12.0"
+      }
+    },
+    "node_modules/@drakkar.software/octobot-client/node_modules/@drakkar.software/starfish-keyring": {
+      "version": "3.0.0-alpha.72",
+      "resolved": "https://registry.npmjs.org/@drakkar.software/starfish-keyring/-/starfish-keyring-3.0.0-alpha.72.tgz",
+      "integrity": "sha512-hjXjn78FuVkarQRsrSssuJ/6R9X8Tvx1h4kvT1JGhl5eZ/hnA13bK7srzYvbAfk0bHIIj+EhNjt2wYFZlurTEw==",
+      "dependencies": {
+        "@drakkar.software/starfish-client": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-protocol": "3.0.0-alpha.72",
+        "@noble/curves": "^2.2.0"
+      }
+    },
+    "node_modules/@drakkar.software/octobot-client/node_modules/@drakkar.software/starfish-protocol": {
+      "version": "3.0.0-alpha.72",
+      "resolved": "https://registry.npmjs.org/@drakkar.software/starfish-protocol/-/starfish-protocol-3.0.0-alpha.72.tgz",
+      "integrity": "sha512-6md+nGBSQCSnU8XGEKPzmPU47XOR0/tOIStcO6YyUcjH1ddhUDLW4zJPTgcuVPV2BGTNqpfPQ7Dsd9oA0YsaDA==",
+      "dependencies": {
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "hash-wasm": "^4.12.0"
+      }
+    },
+    "node_modules/@drakkar.software/octobot-client/node_modules/@drakkar.software/starfish-replica": {
+      "version": "3.0.0-alpha.72",
+      "resolved": "https://registry.npmjs.org/@drakkar.software/starfish-replica/-/starfish-replica-3.0.0-alpha.72.tgz",
+      "integrity": "sha512-ZUVcU2+XjYr6RGzXQzZay41cJp6UtsRNpTz43lZ3yHI0ul7o+lRCrlo5euHkmjhN8JNJuim13SjZDqcfcviGtw==",
+      "dependencies": {
+        "@drakkar.software/starfish-identities": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-protocol": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-server": "3.0.0-alpha.72"
+      },
+      "peerDependencies": {
+        "@drakkar.software/starfish-client": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-keyring": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-spaces": "3.0.0-alpha.72"
+      },
+      "peerDependenciesMeta": {
+        "@drakkar.software/starfish-client": {
+          "optional": true
+        },
+        "@drakkar.software/starfish-keyring": {
+          "optional": true
+        },
+        "@drakkar.software/starfish-spaces": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@drakkar.software/octobot-client/node_modules/@drakkar.software/starfish-server": {
+      "version": "3.0.0-alpha.72",
+      "resolved": "https://registry.npmjs.org/@drakkar.software/starfish-server/-/starfish-server-3.0.0-alpha.72.tgz",
+      "integrity": "sha512-IxiGk6B1hQNWsekluocj9KphFhUZpkfLXfuEc2TCyN/yhOXM8ZmzBrKtHfG8d1p/Q6uLDX60v45AiUEaaZ8iTw==",
+      "dependencies": {
+        "@drakkar.software/starfish-protocol": "3.0.0-alpha.72",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "hono": "^4.12.7"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": ">=3.0.0",
+        "ajv": ">=8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-s3": {
+          "optional": true
+        },
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@drakkar.software/octobot-client/node_modules/@drakkar.software/starfish-sharing": {
+      "version": "3.0.0-alpha.72",
+      "resolved": "https://registry.npmjs.org/@drakkar.software/starfish-sharing/-/starfish-sharing-3.0.0-alpha.72.tgz",
+      "integrity": "sha512-tR4R1zcpQisfoGQrJzaI7oXtPG3HEAW9dTOVnX9LOkCOlvjo++bbrPcThPWJMOH3HYiwmE97uDy1JhqHGrqNbQ==",
+      "dependencies": {
+        "@drakkar.software/starfish-client": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-keyring": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-protocol": "3.0.0-alpha.72"
+      }
+    },
+    "node_modules/@drakkar.software/octobot-client/node_modules/@drakkar.software/starfish-spaces": {
+      "version": "3.0.0-alpha.72",
+      "resolved": "https://registry.npmjs.org/@drakkar.software/starfish-spaces/-/starfish-spaces-3.0.0-alpha.72.tgz",
+      "integrity": "sha512-9UYQPsi1R00WBKgggmxqny90OAbvGhYMgOCXVup86AhW07Fp4qeMwypPfAR++7TsCfmGdP3jFWQynmFzpE/b7Q==",
+      "dependencies": {
+        "@drakkar.software/starfish-client": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-identities": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-keyring": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-protocol": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-server": "3.0.0-alpha.72",
+        "@drakkar.software/starfish-sharing": "3.0.0-alpha.72",
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.0.0",
+        "@scure/bip39": "^1.5.4"
+      }
+    },
+    "node_modules/@drakkar.software/octobot-protocol": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@drakkar.software/octobot-protocol/-/octobot-protocol-0.8.0.tgz",
+      "integrity": "sha512-uMHFka2eq0ulr8Dt0/qCKogoktuNKtgjXEolQ7a7NUca7XxtdqzJnTEM3XkxH4ODZo+D1zCkua48HyWV61NmmA==",
+      "license": "GPL-3.0"
     },
     "node_modules/@drakkar.software/octochat-sdk": {
       "version": "0.8.1",

--- a/packages/tentacles/Services/Interfaces/node_web_interface/package.json
+++ b/packages/tentacles/Services/Interfaces/node_web_interface/package.json
@@ -5,18 +5,15 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "sdk:build": "npm --prefix ../../../../client/octobot_client_ts install --no-audit --no-fund && npm --prefix ../../../../client/octobot_client_ts run build",
-    "prebuild": "npm run sdk:build",
     "build": "tsc -p tsconfig.build.json && vite build",
     "lint": "biome check --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true ./",
     "preview": "vite preview",
     "generate-client": "openapi-ts",
-    "pretest": "npm run sdk:build",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@drakkar.software/octobot-client": "file:../../../../client/octobot_client_ts",
+    "@drakkar.software/octobot-client": "^0.8.0",
     "@drakkar.software/octochat-sdk": "^0.8.1",
     "@drakkar.software/starfish-identities": "3.0.0-alpha.27",
     "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
Follow-up to #3658, now that octobot-client@0.8.0 and octobot-protocol@0.8.0 are actually published on npm.

Replaces the `file:../../../../client/octobot_client_ts` workaround (needed only because 0.8.0 wasn't on the registry yet) with a plain `^0.8.0` range, and drops the `sdk:build`/`prebuild`/`pretest` scripts that were building the sibling package locally — the published tarball already ships a built `dist`, so there's nothing left for them to do.

Verified: `npm ci`, `npm run build`, `npm test` (636/636) all pass against the real dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)