### PR TITLE
[OCT-1] Fix node_web_interface build during tentacles export

### DIFF
--- a/packages/tentacles/Services/Interfaces/node_web_interface/package.json
+++ b/packages/tentacles/Services/Interfaces/node_web_interface/package.json
@@ -5,10 +5,13 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "sdk:build": "npm run build -w @drakkar.software/octobot-client",
+    "prebuild": "npm run sdk:build",
     "build": "tsc -p tsconfig.build.json && vite build",
     "lint": "biome check --write --unsafe --no-errors-on-unmatched --files-ignore-unknown=true ./",
     "preview": "vite preview",
     "generate-client": "openapi-ts",
+    "pretest": "npm run sdk:build",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Summary
Restore `prebuild`/`sdk:build` on `node_web_interface` so `@drakkar.software/octobot-client` builds before the UI (fixes `tsc` TS2307 during tentacles export).

## Accept
CI step **Install OctoBot & tentacles** passes.

OCT-1